### PR TITLE
Add instance profile support

### DIFF
--- a/arbiter/drivers/http.hpp
+++ b/arbiter/drivers/http.hpp
@@ -61,14 +61,14 @@ public:
     /** Perform an HTTP GET request. */
     std::string get(
             std::string path,
-            http::Headers headers,
-            http::Query query) const;
+            http::Headers headers = http::Headers(),
+            http::Query query = http::Query()) const;
 
     /** Perform an HTTP GET request. */
     std::unique_ptr<std::string> tryGet(
             std::string path,
-            http::Headers headers,
-            http::Query query) const;
+            http::Headers headers = http::Headers(),
+            http::Query query = http::Query()) const;
 
     /** Perform an HTTP GET request. */
     std::vector<char> getBinary(

--- a/arbiter/drivers/s3.cpp
+++ b/arbiter/drivers/s3.cpp
@@ -851,7 +851,7 @@ S3::Auth S3::Auth::getStatic() const
             ss >> creds;
             m_access = creds["AccessKeyId"].asString();
             m_hidden = creds["SecretAccessKey"].asString();
-
+            m_token = creds["Token"].asString();
             m_expiration.reset(new Time(creds["Expiration"].asString()));
 
             if (*m_expiration - now < reauthSeconds)

--- a/arbiter/drivers/s3.cpp
+++ b/arbiter/drivers/s3.cpp
@@ -838,8 +838,7 @@ S3::Auth S3::Auth::getStatic() const
             m_access = creds["AccessKeyId"].asString();
             m_hidden = creds["SecretAccessKey"].asString();
 
-            m_expiration.reset(
-                    new Time(creds["Expiration"].asString(), Time::iso8601));
+            m_expiration.reset(new Time(creds["Expiration"].asString()));
 
             if (*m_expiration - now < reauthSeconds)
             {

--- a/arbiter/drivers/s3.cpp
+++ b/arbiter/drivers/s3.cpp
@@ -35,14 +35,18 @@ namespace arbiter
 
 namespace
 {
-    const int64_t reauthSeconds(120);
     http::Pool pool;
     drivers::Http httpDriver(pool);
 
-    // See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+    // See:
+    // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
     const std::string credIp("http://169.254.169.254/");
     const std::string credBase(
             credIp + "latest/meta-data/iam/security-credentials/");
+
+    // Re-fetch credentials when there are less then 4 minutes remaining.  New
+    // ones are guaranteed by AWS to be available within 5 minutes remaining.
+    constexpr int64_t reauthSeconds(60 * 4);
 
     std::string getBaseUrl(const std::string& region)
     {

--- a/arbiter/drivers/s3.hpp
+++ b/arbiter/drivers/s3.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
 #ifndef ARBITER_IS_AMALGAMATION
+#include <arbiter/util/time.hpp>
 #include <arbiter/drivers/http.hpp>
 #endif
 
@@ -33,9 +35,9 @@ public:
             bool precheck = false);
 
     /** Try to construct an S3 Driver.  Searches @p json primarily for the keys
-     * `access` and `hidden` to construct an S3::Auth.  If not found, common
-     * filesystem locations and then the environment will be searched (see
-     * S3::Auth::find).
+     * `access` and `hidden`/`secret` to construct an S3::Auth.  If not found,
+     * common filesystem locations and then the environment will be searched
+     * (see S3::Auth::find).
      *
      * Server-side encryption may be enabled by setting key `sse` to `true` in
      * @p json.
@@ -60,30 +62,7 @@ public:
 
     virtual void copy(std::string src, std::string dst) const override;
 
-    /** @brief AWS authentication information. */
-    class Auth
-    {
-    public:
-        Auth(std::string access, std::string hidden);
-
-        /** @brief Search for credentials in some common locations.
-         *
-         * See:
-         * docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html
-         *
-         * Uses methods 2 and 3 of "Setting AWS Credentials":
-         *      - Check for them in `~/.aws/credentials`.
-         *      - If not found, try the environment settings.
-         */
-        static std::unique_ptr<Auth> find(std::string profile = "");
-
-        std::string access() const;
-        std::string hidden() const;
-
-    private:
-        std::string m_access;
-        std::string m_hidden;
-    };
+    static std::string findRegion();
 
 private:
     /** Inherited from Drivers::Http. */
@@ -97,96 +76,117 @@ private:
             std::string path,
             bool verbose) const override;
 
-    struct Resource
-    {
-        Resource(std::string baseUrl, std::string fullPath);
+    class ApiV4;
+    class Resource;
+    // class FormattedTime;
 
-        std::string url() const;
-        std::string host() const;
-        std::string baseUrl() const { return m_baseUrl; }
-        std::string bucket() const { return m_bucket; }
-        std::string object() const;
-
-    private:
-        std::string m_baseUrl;
-        std::string m_bucket;
-        std::string m_object;
-        bool m_virtualHosted;
-    };
-
-    class FormattedTime
-    {
-    public:
-        FormattedTime();
-
-        const std::string& date() const { return m_date; }
-        const std::string& time() const { return m_time; }
-
-        std::string amazonDate() const
-        {
-            return date() + 'T' + time() + 'Z';
-        }
-
-    private:
-        std::string formatTime(const std::string& format) const;
-
-        const std::string m_date;
-        const std::string m_time;
-    };
-
-    class ApiV4
-    {
-    public:
-        ApiV4(
-                std::string verb,
-                const std::string& region,
-                const Resource& resource,
-                const S3::Auth& auth,
-                const http::Query& query,
-                const http::Headers& headers,
-                const std::vector<char>& data);
-
-        const http::Headers& headers() const { return m_headers; }
-        const http::Query& query() const { return m_query; }
-
-        const std::string& signedHeadersString() const
-        {
-            return m_signedHeadersString;
-        }
-
-    private:
-        std::string buildCanonicalRequest(
-                std::string verb,
-                const Resource& resource,
-                const http::Query& query,
-                const std::vector<char>& data) const;
-
-        std::string buildStringToSign(
-                const std::string& canonicalRequest) const;
-
-        std::string calculateSignature(
-                const std::string& stringToSign) const;
-
-        std::string getAuthHeader(
-                const std::string& signedHeadersString,
-                const std::string& signature) const;
-
-        const S3::Auth& m_auth;
-        const std::string m_region;
-        const FormattedTime m_formattedTime;
-
-        http::Headers m_headers;
-        http::Query m_query;
-        std::string m_canonicalHeadersString;
-        std::string m_signedHeadersString;
-    };
-
-    Auth m_auth;
+    std::unique_ptr<Auth> m_auth;
 
     std::string m_region;
     std::string m_baseUrl;
     http::Headers m_baseHeaders;
     bool m_precheck;
+};
+
+/** @brief AWS authentication information. */
+class S3::Auth
+{
+public:
+    Auth(std::string access, std::string hidden);
+    Auth(std::string iamRole);
+    Auth(const Auth&);
+
+    /** @brief Search for credentials in some common locations.
+     *
+     * Check, in order:
+     *      - Environment settings.
+     *      - Arbiter JSON configuration.
+     *      - Config file `~/.aws/credentials` (searching for @p profile).
+     *      - EC2 instance profile.
+     */
+    static std::unique_ptr<Auth> find(
+            const Json::Value& json,
+            std::string profile = "");
+
+    static std::string region();
+
+    Auth getStatic() const;
+
+    std::string access() const;
+    std::string hidden() const;
+
+private:
+    mutable std::string m_access;
+    mutable std::string m_hidden;
+
+    std::string m_iamRole;
+    mutable std::unique_ptr<Time> m_expiration;
+    mutable std::mutex m_mutex;
+};
+
+class S3::Resource
+{
+public:
+    Resource(std::string baseUrl, std::string fullPath);
+
+    std::string url() const;
+    std::string host() const;
+    std::string baseUrl() const { return m_baseUrl; }
+    std::string bucket() const { return m_bucket; }
+    std::string object() const;
+
+private:
+    std::string m_baseUrl;
+    std::string m_bucket;
+    std::string m_object;
+    bool m_virtualHosted;
+};
+
+class S3::ApiV4
+{
+public:
+    ApiV4(
+            std::string verb,
+            const std::string& region,
+            const Resource& resource,
+            const S3::Auth& auth,
+            const http::Query& query,
+            const http::Headers& headers,
+            const std::vector<char>& data);
+
+    const http::Headers& headers() const { return m_headers; }
+    const http::Query& query() const { return m_query; }
+
+    const std::string& signedHeadersString() const
+    {
+        return m_signedHeadersString;
+    }
+
+private:
+    std::string buildCanonicalRequest(
+            std::string verb,
+            const Resource& resource,
+            const http::Query& query,
+            const std::vector<char>& data) const;
+
+    std::string buildStringToSign(
+            const std::string& canonicalRequest) const;
+
+    std::string calculateSignature(
+            const std::string& stringToSign) const;
+
+    std::string getAuthHeader(
+            const std::string& signedHeadersString,
+            const std::string& signature) const;
+
+    const S3::Auth m_auth;
+    const std::string m_region;
+    const Time m_time;
+
+    http::Headers m_headers;
+    http::Query m_query;
+    std::string m_canonicalHeadersString;
+    std::string m_signedHeadersString;
 };
 
 } // namespace drivers

--- a/arbiter/drivers/s3.hpp
+++ b/arbiter/drivers/s3.hpp
@@ -92,7 +92,7 @@ private:
 class S3::Auth
 {
 public:
-    Auth(std::string access, std::string hidden);
+    Auth(std::string access, std::string hidden, std::string token = "");
     Auth(std::string iamRole);
     Auth(const Auth&);
 
@@ -114,10 +114,12 @@ public:
 
     std::string access() const;
     std::string hidden() const;
+    std::string token() const;
 
 private:
     mutable std::string m_access;
     mutable std::string m_hidden;
+    mutable std::string m_token;
 
     std::string m_iamRole;
     mutable std::unique_ptr<Time> m_expiration;

--- a/arbiter/util/CMakeLists.txt
+++ b/arbiter/util/CMakeLists.txt
@@ -7,6 +7,7 @@ set(
     "${BASE}/http.cpp"
     "${BASE}/md5.cpp"
     "${BASE}/sha256.cpp"
+    "${BASE}/time.cpp"
     "${BASE}/transforms.cpp"
     "${BASE}/util.cpp"
 )
@@ -18,6 +19,7 @@ set(
     "${BASE}/macros.hpp"
     "${BASE}/md5.hpp"
     "${BASE}/sha256.hpp"
+    "${BASE}/time.hpp"
     "${BASE}/transforms.hpp"
     "${BASE}/types.hpp"
     "${BASE}/util.hpp"

--- a/arbiter/util/http.cpp
+++ b/arbiter/util/http.cpp
@@ -149,7 +149,7 @@ Response Resource::exec(std::function<Response()> f)
 Pool::Pool(
         const std::size_t concurrent,
         const std::size_t retry,
-        const Json::Value& json)
+        const Json::Value json)
     : m_curls(concurrent)
     , m_available(concurrent)
     , m_retry(retry)
@@ -159,11 +159,13 @@ Pool::Pool(
     curl_global_init(CURL_GLOBAL_ALL);
 
     const bool verbose(
-            json.isMember("arbiter") ?
+            !json.isNull() && json.isMember("arbiter") ?
                 json["arbiter"]["verbose"].asBool() : false);
 
     const std::size_t timeout(
-            json.isMember("http") && json["http"]["timeout"].asUInt64() ?
+            !json.isNull() &&
+            json.isMember("http") &&
+            json["http"]["timeout"].asUInt64() ?
                 json["http"]["timeout"].asUInt64() : defaultHttpTimeout);
 
     for (std::size_t i(0); i < concurrent; ++i)

--- a/arbiter/util/http.hpp
+++ b/arbiter/util/http.hpp
@@ -93,9 +93,9 @@ class Pool
 
 public:
     Pool(
-            std::size_t concurrent,
-            std::size_t retry,
-            const Json::Value& json);
+            std::size_t concurrent = 4,
+            std::size_t retry = 4,
+            Json::Value json = Json::Value());
     ~Pool();
 
     Resource acquire();

--- a/arbiter/util/time.cpp
+++ b/arbiter/util/time.cpp
@@ -1,0 +1,75 @@
+#ifndef ARBITER_IS_AMALGAMATION
+#include <arbiter/util/time.hpp>
+#endif
+
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+
+namespace arbiter
+{
+
+namespace
+{
+    std::mutex mutex;
+
+    int64_t utcOffsetSeconds()
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        std::time_t now(std::time(nullptr));
+        std::tm utc(*std::gmtime(&now));
+        std::tm loc(*std::localtime(&now));
+        return std::difftime(std::mktime(&utc), std::mktime(&loc));
+    }
+
+    std::tm getTm()
+    {
+        std::tm tm;
+        tm.tm_sec = 0;
+        tm.tm_min = 0;
+        tm.tm_hour = 0;
+        tm.tm_mday = 0;
+        tm.tm_mon = 0;
+        tm.tm_year = 0;
+        tm.tm_wday = 0;
+        tm.tm_yday = 0;
+        tm.tm_isdst = 0;
+        return tm;
+    }
+}
+
+const std::string Time::iso8601 = "%FT%TZ";
+const std::string Time::iso8601NoSeparators = "%Y%m%dT%H%M%SZ";
+const std::string Time::dateNoSeparators = "%Y%m%d";
+
+Time::Time()
+{
+    m_time = std::time(nullptr);
+}
+
+Time::Time(const std::string& s, const std::string& format)
+{
+    static const int64_t utcOffset(utcOffsetSeconds());
+
+    auto tm(getTm());
+    std::istringstream ss(s);
+    ss >> std::get_time(&tm, format.c_str());
+    tm.tm_sec -= utcOffset;
+    m_time = std::mktime(&tm);
+}
+
+std::string Time::str(const std::string& format) const
+{
+    std::ostringstream ss;
+    std::lock_guard<std::mutex> lock(mutex);
+    ss << std::put_time(std::gmtime(&m_time), format.c_str());
+    return ss.str();
+}
+
+int64_t Time::operator-(const Time& other) const
+{
+    return std::difftime(m_time, other.m_time);
+}
+
+} // namespace arbiter
+

--- a/arbiter/util/time.cpp
+++ b/arbiter/util/time.cpp
@@ -38,7 +38,7 @@ namespace
     }
 }
 
-const std::string Time::iso8601 = "%FT%TZ";
+const std::string Time::iso8601 = "%Y-%m-%dT%H:%M:%SZ";
 const std::string Time::iso8601NoSeparators = "%Y%m%dT%H%M%SZ";
 const std::string Time::dateNoSeparators = "%Y%m%d";
 

--- a/arbiter/util/time.hpp
+++ b/arbiter/util/time.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <ctime>
+#include <string>
+
+namespace arbiter
+{
+
+class Time
+{
+public:
+    static const std::string iso8601;
+    static const std::string iso8601NoSeparators;
+    static const std::string dateNoSeparators;
+
+    Time();
+    Time(const std::string& s, const std::string& format = iso8601);
+
+    std::string str(const std::string& format = iso8601) const;
+
+    // Return value is in seconds.
+    int64_t operator-(const Time& other) const;
+
+private:
+    std::time_t m_time;
+};
+
+} // namespace arbiter
+


### PR DESCRIPTION
Add EC2 instance profile support for the S3 driver, as the lowest priority auth method for S3.  Closes #8.