### PR TITLE
Implement missing windows functionality

### DIFF
--- a/arbiter/drivers/fs.cpp
+++ b/arbiter/drivers/fs.cpp
@@ -12,6 +12,7 @@
 #include <locale>
 #include <codecvt>
 #include <windows.h>
+#include <direct.h>
 #endif
 
 #include <algorithm>
@@ -157,7 +158,6 @@ namespace fs
 
 bool mkdirp(std::string raw)
 {
-#ifndef ARBITER_WINDOWS
     const std::string dir(([&raw]()
     {
         std::string s(expandTilde(raw));
@@ -182,27 +182,24 @@ bool mkdirp(std::string raw)
         it = std::find_if(++it, end, util::isSlash);
 
         const std::string cur(dir.begin(), it);
+#ifndef ARBITER_WINDOWS
         const bool err(::mkdir(cur.c_str(), S_IRWXU | S_IRGRP | S_IROTH));
+#else
+        const bool err(::_mkdir(cur.c_str()));
+#endif
         if (err && errno != EEXIST) return false;
     }
     while (it != end);
 
     return true;
 
-#else
-    throw ArbiterError("Windows mkdirp not done yet.");
-#endif
 }
 
 bool remove(std::string filename)
 {
     filename = expandTilde(filename);
 
-#ifndef ARBITER_WINDOWS
     return ::remove(filename.c_str()) == 0;
-#else
-    throw ArbiterError("Windows remove not done yet.");
-#endif
 }
 
 namespace

--- a/arbiter/drivers/fs.cpp
+++ b/arbiter/drivers/fs.cpp
@@ -184,10 +184,12 @@ bool mkdirp(std::string raw)
         const std::string cur(dir.begin(), it);
 #ifndef ARBITER_WINDOWS
         const bool err(::mkdir(cur.c_str(), S_IRWXU | S_IRGRP | S_IROTH));
-#else
-        const bool err(::_mkdir(cur.c_str()));
-#endif
         if (err && errno != EEXIST) return false;
+#else
+        // Use CreateDirectory instead of _mkdir; it is more reliable when creating directories on a drive other than the working path.
+        const bool err(::CreateDirectory(cur.c_str(), NULL));
+        if (err && ::GetLastError() != ERROR_ALREADY_EXISTS) return false;
+#endif
     }
     while (it != end);
 


### PR DESCRIPTION
Functions which were previously unimplemented on windows, possibly originally because expandTilde was also not yet implemented, have now been completed. This should resolve #16. The existing tests ran fine, however the build took some tweaking to work from vs2017.
@connormanning, if this pull request is acceptable would you like me to submit a similar one for entwine? At this stage I've just applied the changes manually to the amalgamated library there; re-running the amalgamate script seem to generate something a bit more complex that the version already present in that repo. I don't know if it's a different version or I'm missing some args to the amalgamation script, or what.