### PR TITLE
BugFix: Calculate UTC time offset based on current time when `mktime()` fails.

### DIFF
--- a/arbiter/util/time.cpp
+++ b/arbiter/util/time.cpp
@@ -60,7 +60,8 @@ Time::Time(const std::string& s, const std::string& format)
         throw ArbiterError("Failed to parse " + s + " as time: " + format);
     }
 #endif
-    const int64_t utcOffset(utcOffsetSeconds(std::mktime(&tm)));
+    std::time_t time = std::mktime(&tm)!=-1 ? std::mktime(&tm) :std::time(nullptr);
+    const int64_t utcOffset(utcOffsetSeconds(time));
 
     if (utcOffset > std::numeric_limits<int>::max())
         throw ArbiterError("Can't convert offset time in seconds to tm type.");


### PR DESCRIPTION
- **Issue :** Earlier we're not able to fetch files from Google Cloud Storage (GCS) on windows.
After checking arbiter I notices that arbiter failed to retrive Authentication token from Google due to invalid expiration time, which depends on UTC to Local time difference.
Aftre debugging I noticed the `std::mktime()` returned -1 since it was not able represent `std::tm` as a `std::time_t` object. According to [std::mktime documentation](https://en.cppreference.com/w/cpp/chrono/c/mktime).
- **Fix :** In this PR I have updated `Time()` constructor to use `std::time(nullptr)` (i.e. Current local time) if `std::mktime()` fails (i.e. returned -1).
