### PR TITLE
Sanitize object path in Google::put()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode
 
 dist/*
 build/*

--- a/arbiter/drivers/google.cpp
+++ b/arbiter/drivers/google.cpp
@@ -79,7 +79,7 @@ namespace
     };
     
     // https://cloud.google.com/storage/docs/json_api/#encoding
-    const std::string GResource::exclusion("!$&'()*+,;=:@");
+    const std::string GResource::exclusions("!$&'()*+,;=:@");
     
 } // unnamed namespace
 

--- a/arbiter/drivers/google.cpp
+++ b/arbiter/drivers/google.cpp
@@ -53,11 +53,9 @@ namespace
 
         const std::string& bucket() const { return m_bucket; }
         const std::string& object() const { return m_object; }
+        static const std::string exclusions;
         std::string endpoint() const
         {
-            // https://cloud.google.com/storage/docs/json_api/#encoding
-            static const std::string exclusions("!$&'()*+,;=:@");
-
             // https://cloud.google.com/storage/docs/json_api/v1/
             return
                 baseGoogleUrl + "b/" + bucket() +
@@ -79,6 +77,10 @@ namespace
         std::string m_object;
 
     };
+    
+    // https://cloud.google.com/storage/docs/json_api/#encoding
+    const std::string GResource::exclusion("!$&'()*+,;=:@");
+    
 } // unnamed namespace
 
 namespace drivers
@@ -159,7 +161,7 @@ void Google::put(
 
     http::Query query(userQuery);
     query["uploadType"] = "media";
-    query["name"] = resource.object();
+    query["name"] = http::sanitize(resource.object(), GResource::exclusions);
 
     drivers::Https https(m_pool);
     const auto res(https.internalPost(url, data, headers, query));


### PR DESCRIPTION
- **Issue :**  We're using arbiter to upload and download files from Google Cloud Stoage (GCS). We've noticed that the files with some special characters (e.g. a space) in their name are not getting uploaded to GCS. After debugging arbiter I got to know that arbiter makes an http post request to Google upload endpoint. So the special characters in the upload request needs to be converted to their correponding `%XX` format.
- **Fix :** In this PR I have updated `Google::put()` to Sanitize the resource object path, So that special characters are converted in their `%XX` format. `! $ & ' ( ) * + , ; = : @` these characters will be ignored since they need not be encoded, As mentioned here: https://cloud.google.com/storage/docs/json_api/#encoding