### PR TITLE
Feature/chunked download for localhandle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode
 
 dist/*
 build/*

--- a/arbiter/drivers/google.cpp
+++ b/arbiter/drivers/google.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<std::size_t> Google::tryGetSize(const std::string path) const
     if (res.ok() && res.headers().count("Content-Length"))
     {
         const auto& s(res.headers().at("Content-Length"));
-        return makeUnique<std::size_t>(std::stoul(s));
+        return makeUnique<std::size_t>(std::stoull(s));
     }
 
     return std::unique_ptr<std::size_t>();

--- a/arbiter/drivers/google.cpp
+++ b/arbiter/drivers/google.cpp
@@ -53,11 +53,9 @@ namespace
 
         const std::string& bucket() const { return m_bucket; }
         const std::string& object() const { return m_object; }
+        static const std::string exclusions;
         std::string endpoint() const
         {
-            // https://cloud.google.com/storage/docs/json_api/#encoding
-            static const std::string exclusions("!$&'()*+,;=:@");
-
             // https://cloud.google.com/storage/docs/json_api/v1/
             return
                 baseGoogleUrl + "b/" + bucket() +
@@ -79,6 +77,10 @@ namespace
         std::string m_object;
 
     };
+    
+    // https://cloud.google.com/storage/docs/json_api/#encoding
+    const std::string GResource::exclusions("!$&'()*+,;=:@");
+    
 } // unnamed namespace
 
 namespace drivers
@@ -159,7 +161,7 @@ void Google::put(
 
     http::Query query(userQuery);
     query["uploadType"] = "media";
-    query["name"] = resource.object();
+    query["name"] = http::sanitize(resource.object(), GResource::exclusions);
 
     drivers::Https https(m_pool);
     const auto res(https.internalPost(url, data, headers, query));

--- a/arbiter/endpoint.cpp
+++ b/arbiter/endpoint.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<LocalHandle> Endpoint::getLocalHandle(
             uint32_t numChunks = ((fileSize % chunkSize) == 0)
                                      ? (fileSize / chunkSize)
                                      : (fileSize / chunkSize) + 1;
-            int32_t start;
+            std::size_t start;
             std::ofstream stream(local, std::ofstream::binary |
                                         std::ofstream::out |
                                         std::ofstream::app);


### PR DESCRIPTION
- **Issue:** Earlier when trying to get a local handle for a remote file (~9 GB), The app was crashing due to continuous download.

- **Fix:** In this PR I am applying a chunked download(100MB each) for all `http derived drivers`. This will not flood the RAM and only 100 MB part of a file will be in th memory. This simply adds a `Range` header to http request.

This somehow relates to https://github.com/connormanning/arbiter/issues/12