### PR TITLE
Feature/chunked upload for google driver

### DIFF
--- a/arbiter/drivers/fs.cpp
+++ b/arbiter/drivers/fs.cpp
@@ -153,6 +153,35 @@ std::vector<std::string> Fs::glob(std::string path, bool verbose) const
     return arbiter::glob(path);
 }
 
+std::vector<char> Fs::getBinaryChunk(std::string path, size_t start,
+    size_t end) const {
+    std::vector<char> retBuffer;
+    std::ifstream iStream(path, std::ifstream::binary | std::ios::in);
+    if (!iStream.good()) {
+        throw ArbiterError("Unable to open "+ path);
+    }
+
+    iStream.seekg(0, std::ios::end);
+    if (end > iStream.tellg()) end = iStream.tellg();
+	
+    retBuffer.clear();
+    retBuffer.resize(end - start);
+	
+    iStream.seekg(start, std::ios::beg);
+    if (!iStream.good()) {
+        throw ArbiterError("Unable to Move to "+ std::to_string(start));
+    }
+
+    iStream.read(retBuffer.data(), end - start);
+    if (!iStream.good()) {
+        throw ArbiterError("Unable to read " + std::to_string(start) + " - " + std::to_string(end));
+    }
+	
+    iStream.close();
+
+    return retBuffer;
+}
+
 } // namespace drivers
 
 

--- a/arbiter/drivers/fs.cpp
+++ b/arbiter/drivers/fs.cpp
@@ -154,7 +154,8 @@ std::vector<std::string> Fs::glob(std::string path, bool verbose) const
 }
 
 std::vector<char> Fs::getBinaryChunk(std::string path, size_t start,
-    size_t end) const {
+    size_t end) const 
+{
     std::vector<char> retBuffer;
     std::ifstream iStream(path, std::ifstream::binary | std::ios::in);
     if (!iStream.good()) {
@@ -164,7 +165,6 @@ std::vector<char> Fs::getBinaryChunk(std::string path, size_t start,
     iStream.seekg(0, std::ios::end);
     if (end > iStream.tellg()) end = iStream.tellg();
 	
-    retBuffer.clear();
     retBuffer.resize(end - start);
 	
     iStream.seekg(start, std::ios::beg);

--- a/arbiter/drivers/fs.hpp
+++ b/arbiter/drivers/fs.hpp
@@ -119,6 +119,8 @@ public:
     virtual bool isRemote() const override { return false; }
 
     virtual void copy(std::string src, std::string dst) const override;
+	
+    std::vector<char> getBinaryChunk(std::string path, size_t start, size_t end) const;
 
 protected:
     virtual bool get(std::string path, std::vector<char>& data) const override;

--- a/arbiter/drivers/google.hpp
+++ b/arbiter/drivers/google.hpp
@@ -38,6 +38,8 @@ public:
             http::Headers headers,
             http::Query query) const override;
 
+    void upload(std::string path, const std::string resourcepath) const;
+
 private:
     /** Inherited from Drivers::Http. */
     virtual bool get(

--- a/arbiter/endpoint.cpp
+++ b/arbiter/endpoint.cpp
@@ -288,8 +288,12 @@ void Endpoint::upload(const std::string subpath, const std::string resourcePath)
     if (m_driver.type()=="gs"){
         drivers::Google* gDriver = (drivers::Google*)&m_driver;
         gDriver->upload(fullPath(subpath), resourcePath);
-    } else
-        throw ArbiterError("Chunked upload is only availabe for Google Driver.");    
+    } else {
+        drivers::Fs fs;
+        size_t fileSize = fs.getSize(resourcePath);
+        const auto data(fs.getBinaryChunk(resourcePath, 0, fileSize));
+        put(resourcePath, data);
+    }
 }
 
 } // namespace arbiter

--- a/arbiter/endpoint.cpp
+++ b/arbiter/endpoint.cpp
@@ -22,8 +22,6 @@ namespace arbiter
 
 namespace
 {
-    constexpr std::size_t mb = 1024 * 1024;
-    const std::size_t chunkSize = 10 * mb;
     const auto streamFlags(
         std::ofstream::binary |
         std::ofstream::out |
@@ -284,6 +282,14 @@ const drivers::Http& Endpoint::getHttpDriver() const
 {
     if (auto d = tryGetHttpDriver()) return *d;
     else throw ArbiterError("Cannot get driver of type " + type() + " as HTTP");
+}
+
+void Endpoint::upload(const std::string subpath, const std::string resourcePath) const {
+    if (m_driver.type()=="gs"){
+        drivers::Google* gDriver = (drivers::Google*)&m_driver;
+        gDriver->upload(fullPath(subpath), resourcePath);
+    } else
+        throw ArbiterError("Chunked upload is only availabe for Google Driver.");    
 }
 
 } // namespace arbiter

--- a/arbiter/endpoint.hpp
+++ b/arbiter/endpoint.hpp
@@ -183,6 +183,9 @@ public:
             http::Headers headers = http::Headers(),
             http::Query query = http::Query()) const;
 
+    void Endpoint::upload(
+	     const std::string subpath, const std::string resourcePath) const;
+
 private:
     Endpoint(const Driver& driver, std::string root);
 

--- a/arbiter/util/util.hpp
+++ b/arbiter/util/util.hpp
@@ -18,6 +18,9 @@ namespace ARBITER_CUSTOM_NAMESPACE
 namespace arbiter
 {
 
+constexpr std::size_t mb = 1024 * 1024;
+const std::size_t chunkSize = 10 * mb;
+
 /** General utilities. */
 
 /** Returns @p path, less any trailing glob indicators (one or two


### PR DESCRIPTION
This PR will add an upload API for Endpoint. Currently I have implemented this option for Google Driver only, Since I am not familier with resumeable upload feature from other sources. So if the driver is other than Google, this will perform a normal Endpoint::put.

Issue: Currently we have put APIs for all Drivers, But its limitation is that it need all content in memory. e.g. If I want to write a 10GB file to Google then I have to first read all file in memory and the I can call put API for Google Driver to write the content to file on Google Cloud. This will work only if I have sufficient RAM to store file content.

Fix: As a fix I am using a Resumable upload feature, this will create a upload session for uploading large file, then perform a chunked upload to session URI.

Google's resumable upload documentation: https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload