### PR TITLE
Lookup session token when checking aws credentials file

### DIFF
--- a/arbiter/drivers/s3.cpp
+++ b/arbiter/drivers/s3.cpp
@@ -220,11 +220,18 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
     {
         const std::string accessKey("aws_access_key_id");
         const std::string hiddenKey("aws_secret_access_key");
+        const std::string tokenKey("aws_session_token");
         const ini::Contents creds(ini::parse(*c));
         if (creds.count(profile))
         {
             const auto section(creds.at(profile));
-            if (section.count(accessKey) && section.count(hiddenKey))
+            if (section.count(accessKey) && section.count(hiddenKey) && section.count(tokenKey))
+            {
+                const auto access(section.at(accessKey));
+                const auto hidden(section.at(hiddenKey));
+                const auto token(section.at(tokenKey));
+                return makeUnique<Auth>(access, hidden, token);
+            } else if (section.count(accessKey) && section.count(hiddenKey))
             {
                 const auto access(section.at(accessKey));
                 const auto hidden(section.at(hiddenKey));

--- a/arbiter/drivers/s3.cpp
+++ b/arbiter/drivers/s3.cpp
@@ -225,18 +225,17 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
         if (creds.count(profile))
         {
             const auto section(creds.at(profile));
-            if (section.count(accessKey) && section.count(hiddenKey) && section.count(tokenKey))
+            if (section.count(accessKey) && section.count(hiddenKey))
             {
                 const auto access(section.at(accessKey));
                 const auto hidden(section.at(hiddenKey));
-                const auto token(section.at(tokenKey));
-                return makeUnique<Auth>(access, hidden, token);
-            } else if (section.count(accessKey) && section.count(hiddenKey))
-            {
-                const auto access(section.at(accessKey));
-                const auto hidden(section.at(hiddenKey));
+                if (section.count(tokenKey))
+                {
+                    const auto token(section.at(tokenKey));
+                    return makeUnique<Auth>(access, hidden, token);
+                }
                 return makeUnique<Auth>(access, hidden);
-            }
+           }
         }
     }
 


### PR DESCRIPTION
I have access key, secret, and session token stored in aws credentials file (updated via saml/sso) and need those to be pulled in when using pdal, for example:
```bash
export AWS_REGION=us-west-2
export AWS_PROFILE=account-profile
pdal info --schema s3://bucketname/ept.json
```
Currently, the above works when `account-profile` doesn't have a session token, but gives a generic reader error:
```
PDAL: readers.ept: No driver for s3://bucketname/ept.json
```
when the profile has a session token with it. This PR adds a lookup for a session token.