### PR TITLE
IMDSv2 support for S3

### DIFF
--- a/arbiter/arbiter.cpp
+++ b/arbiter/arbiter.cpp
@@ -153,12 +153,16 @@ std::unique_ptr<std::size_t> Arbiter::tryGetSize(const std::string path) const
     return getDriver(path).tryGetSize(stripProtocol(path));
 }
 
-void Arbiter::put(const std::string path, const std::string& data) const
+std::vector<char> Arbiter::put(
+        const std::string path, 
+        const std::string& data) const
 {
     return getDriver(path).put(stripProtocol(path), data);
 }
 
-void Arbiter::put(const std::string path, const std::vector<char>& data) const
+std::vector<char> Arbiter::put(
+        const std::string path, 
+        const std::vector<char>& data) const
 {
     return getDriver(path).put(stripProtocol(path), data);
 }
@@ -195,7 +199,7 @@ std::unique_ptr<std::vector<char>> Arbiter::tryGetBinary(
     return getHttpDriver(path).tryGetBinary(stripProtocol(path), headers, query);
 }
 
-void Arbiter::put(
+std::vector<char> Arbiter::put(
         const std::string path,
         const std::string& data,
         const http::Headers headers,
@@ -204,7 +208,7 @@ void Arbiter::put(
     return getHttpDriver(path).put(stripProtocol(path), data, headers, query);
 }
 
-void Arbiter::put(
+std::vector<char> Arbiter::put(
         const std::string path,
         const std::vector<char>& data,
         const http::Headers headers,

--- a/arbiter/arbiter.hpp
+++ b/arbiter/arbiter.hpp
@@ -90,10 +90,12 @@ public:
     std::unique_ptr<std::size_t> tryGetSize(std::string path) const;
 
     /** Write data to path. */
-    void put(std::string path, const std::string& data) const;
+    std::vector<char> put(std::string path, const std::string& data) const;
 
     /** Write data to path. */
-    void put(std::string path, const std::vector<char>& data) const;
+    std::vector<char> put(
+            std::string path, 
+            const std::vector<char>& data) const;
 
     /** Get data with additional HTTP-specific parameters.  Throws if
      * isHttpDerived is false for this path. */
@@ -125,7 +127,7 @@ public:
 
     /** Write data to path with additional HTTP-specific parameters.
      * Throws if isHttpDerived is false for this path. */
-    void put(
+    std::vector<char> put(
             std::string path,
             const std::string& data,
             http::Headers headers,
@@ -133,7 +135,7 @@ public:
 
     /** Write data to path with additional HTTP-specific parameters.
      * Throws if isHttpDerived is false for this path. */
-    void put(
+    std::vector<char> put(
             std::string path,
             const std::vector<char>& data,
             http::Headers headers,

--- a/arbiter/driver.cpp
+++ b/arbiter/driver.cpp
@@ -46,9 +46,9 @@ std::size_t Driver::getSize(const std::string path) const
     else throw ArbiterError("Could not get size of " + path);
 }
 
-void Driver::put(std::string path, const std::string& data) const
+std::vector<char> Driver::put(std::string path, const std::string& data) const
 {
-    put(path, std::vector<char>(data.begin(), data.end()));
+    return put(path, std::vector<char>(data.begin(), data.end()));
 }
 
 void Driver::copy(std::string src, std::string dst) const

--- a/arbiter/driver.hpp
+++ b/arbiter/driver.hpp
@@ -69,7 +69,9 @@ public:
      *
      * @param path Path with the type-specifying prefix information stripped.
      */
-    virtual void put(std::string path, const std::vector<char>& data) const = 0;
+    virtual std::vector<char> put(
+        std::string path, 
+        const std::vector<char>& data) const = 0;
 
     /** True for remote paths, otherwise false.  If `true`, a fs::LocalHandle
      * request will download and write this file to the local filesystem.
@@ -83,7 +85,7 @@ public:
     std::size_t getSize(std::string path) const;
 
     /** Write string data. */
-    void put(std::string path, const std::string& data) const;
+    std::vector<char> put(std::string path, const std::string& data) const;
 
     /** Copy a file, where @p src and @p dst must both be of this driver
      * type.  Type-prefixes must be stripped from the input parameters.

--- a/arbiter/drivers/az.cpp
+++ b/arbiter/drivers/az.cpp
@@ -398,7 +398,7 @@ bool AZ::get(
     }
 }
 
-void AZ::put(
+std::vector<char> AZ::put(
         const std::string rawPath,
         const std::vector<char>& data,
         const Headers userHeaders,
@@ -439,7 +439,7 @@ void AZ::put(
                     "Couldn't Azure PUT to " + rawPath + ": " +
                     std::string(res.data().data(), res.data().size()));
         }
-        return;
+        return res.data();
     }
 
     const ApiV1 ApiV1(
@@ -463,6 +463,8 @@ void AZ::put(
                 "Couldn't Azure PUT to " + rawPath + ": " +
                 std::string(res.data().data(), res.data().size()));
     }
+
+    return res.data();
 }
 
 void AZ::copy(const std::string src, const std::string dst) const

--- a/arbiter/drivers/az.hpp
+++ b/arbiter/drivers/az.hpp
@@ -51,7 +51,7 @@ public:
             std::string path) const override;
 
     /** Inherited from Drivers::Http. */
-    virtual void put(
+    virtual std::vector<char> put(
             std::string path,
             const std::vector<char>& data,
             http::Headers headers,

--- a/arbiter/drivers/dropbox.cpp
+++ b/arbiter/drivers/dropbox.cpp
@@ -193,7 +193,7 @@ bool Dropbox::get(
     return false;
 }
 
-void Dropbox::put(
+std::vector<char> Dropbox::put(
         const std::string path,
         const std::vector<char>& data,
         const Headers userHeaders,
@@ -208,6 +208,7 @@ void Dropbox::put(
     const Response res(Http::internalPost(putUrl, data, headers, query));
 
     if (!res.ok()) throw ArbiterError(res.str());
+    return res.data();
 }
 
 std::string Dropbox::continueFileInfo(std::string cursor) const

--- a/arbiter/drivers/dropbox.hpp
+++ b/arbiter/drivers/dropbox.hpp
@@ -33,7 +33,7 @@ public:
     static std::unique_ptr<Dropbox> create(http::Pool& pool, std::string j);
 
     virtual std::string type() const override { return "dropbox"; }
-    virtual void put(
+    virtual std::vector<char> put(
             std::string path,
             const std::vector<char>& data,
             http::Headers headers,

--- a/arbiter/drivers/fs.cpp
+++ b/arbiter/drivers/fs.cpp
@@ -108,7 +108,7 @@ bool Fs::get(std::string path, std::vector<char>& data) const
     return good;
 }
 
-void Fs::put(std::string path, const std::vector<char>& data) const
+std::vector<char> Fs::put(std::string path, const std::vector<char>& data) const
 {
     path = expandTilde(path);
     std::ofstream stream(path, binaryTruncMode);
@@ -124,6 +124,7 @@ void Fs::put(std::string path, const std::vector<char>& data) const
     {
         throw ArbiterError("Error occurred while writing " + path);
     }
+    return std::vector<char>();
 }
 
 void Fs::copy(std::string src, std::string dst) const

--- a/arbiter/drivers/fs.hpp
+++ b/arbiter/drivers/fs.hpp
@@ -105,7 +105,7 @@ public:
     virtual std::unique_ptr<std::size_t> tryGetSize(
             std::string path) const override;
 
-    virtual void put(
+    virtual std::vector<char> put(
             std::string path,
             const std::vector<char>& data) const override;
 

--- a/arbiter/drivers/google.cpp
+++ b/arbiter/drivers/google.cpp
@@ -149,7 +149,7 @@ bool Google::get(
     }
 }
 
-void Google::put(
+std::vector<char> Google::put(
         const std::string path,
         const std::vector<char>& data,
         const http::Headers userHeaders,
@@ -168,6 +168,8 @@ void Google::put(
 
     drivers::Https https(m_pool);
     const auto res(https.internalPost(url, data, headers, query));
+    if (!res.ok()) throw ArbiterError(res.str());
+    return res.data();
 }
 
 std::vector<std::string> Google::glob(std::string path, bool verbose) const

--- a/arbiter/drivers/google.hpp
+++ b/arbiter/drivers/google.hpp
@@ -32,7 +32,7 @@ public:
             std::string path) const override;
 
     /** Inherited from Drivers::Http. */
-    virtual void put(
+    virtual std::vector<char> put(
             std::string path,
             const std::vector<char>& data,
             http::Headers headers,

--- a/arbiter/drivers/http.cpp
+++ b/arbiter/drivers/http.cpp
@@ -119,13 +119,17 @@ std::unique_ptr<std::vector<char>> Http::tryGetBinary(
     return data;
 }
 
-void Http::put(
+std::vector<char> Http::put(
         std::string path,
         const std::string& data,
         const Headers headers,
         const Query query) const
 {
-    put(path, std::vector<char>(data.begin(), data.end()), headers, query);
+    return put(
+        path, 
+        std::vector<char>(data.begin(), data.end()), 
+        headers, 
+        query);
 }
 
 bool Http::get(
@@ -148,18 +152,21 @@ bool Http::get(
     return good;
 }
 
-void Http::put(
+std::vector<char> Http::put(
         const std::string path,
         const std::vector<char>& data,
         const Headers headers,
         const Query query) const
 {
     auto http(m_pool.acquire());
+    auto res(http.put(typedPath(path), data, headers, query));
 
-    if (!http.put(typedPath(path), data, headers, query).ok())
+    if (!res.ok())
     {
         throw ArbiterError("Couldn't HTTP PUT to " + path);
     }
+
+    return res.data();
 }
 
 void Http::post(

--- a/arbiter/drivers/http.hpp
+++ b/arbiter/drivers/http.hpp
@@ -41,11 +41,11 @@ public:
     virtual std::unique_ptr<std::size_t> tryGetSize(
             std::string path) const override;
 
-    virtual void put(
+    virtual std::vector<char> put(
             std::string path,
             const std::vector<char>& data) const final override
     {
-        put(path, data, http::Headers(), http::Query());
+        return put(path, data, http::Headers(), http::Query());
     }
 
     /* HTTP-specific driver methods follow.  Since many drivers (S3, Dropbox,
@@ -93,7 +93,7 @@ public:
             http::Query query) const;
 
     /** Perform an HTTP PUT request. */
-    void put(
+    std::vector<char> put(
             std::string path,
             const std::string& data,
             http::Headers headers,
@@ -104,7 +104,7 @@ public:
      */
 
     /** Perform an HTTP PUT request. */
-    virtual void put(
+    virtual std::vector<char> put(
             std::string path,
             const std::vector<char>& data,
             http::Headers headers,

--- a/arbiter/drivers/s3.hpp
+++ b/arbiter/drivers/s3.hpp
@@ -57,7 +57,7 @@ public:
             std::string path) const override;
 
     /** Inherited from Drivers::Http. */
-    virtual void put(
+    virtual std::vector<char> put(
             std::string path,
             const std::vector<char>& data,
             http::Headers headers,


### PR DESCRIPTION
Very similar to before, except before querying the IAM endpoint we need to fetch a token.  Since that token is fetched via a `PUT` request, there is some diff noise here since previously our `PUT` calls returned `void`, but now we actually need the response data.  Fixes #44.