### PR TITLE
fix az driver

### DIFF
--- a/arbiter/drivers/az.cpp
+++ b/arbiter/drivers/az.cpp
@@ -66,7 +66,7 @@ AZ::AZ(
         Pool& pool,
         std::string profile,
         std::unique_ptr<Config> config)
-    : Http(pool, "az", profile == "default" ? "" : profile)
+    : Http(pool, "az", "http", profile == "default" ? "" : profile)
     , m_config(std::move(config))
 { }
 
@@ -256,7 +256,10 @@ std::string AZ::Config::extractBaseUrl(
     return account + "." + service + "." + endpoint + "/";
 }
 
-std::unique_ptr<std::size_t> AZ::tryGetSize(std::string rawPath) const
+std::unique_ptr<std::size_t> AZ::tryGetSize(
+    const std::string rawPath,
+    const http::Headers userHeaders,
+    const http::Query query) const
 {
     Headers headers(m_config->baseHeaders());
 
@@ -267,6 +270,7 @@ std::unique_ptr<std::size_t> AZ::tryGetSize(std::string rawPath) const
     if (m_config->hasSasToken())
     {
         Query q = m_config->sasToken();
+        q.insert(std::cbegin(query),std::cend(query));
         res.reset(new Response(http.internalHead(resource.url(), headers, q)));
     }
     else

--- a/arbiter/drivers/az.hpp
+++ b/arbiter/drivers/az.hpp
@@ -45,7 +45,9 @@ public:
 
     // Overrides.
     virtual std::unique_ptr<std::size_t> tryGetSize(
-            std::string path) const override;
+            std::string path,
+            http::Headers headers,
+            http::Query query = http::Query()) const override;
 
     /** Inherited from Drivers::Http. */
     virtual std::vector<char> put(


### PR DESCRIPTION
`AZ` driver was missing `override` for `std::unique_ptr<std::size_t> tryGetSize(std::string path, http::Headers headers, http::Query query) const`.
`Protocol` was missing on init as well.

As a consequence, most `az://` requests were failing.

cf : [PDAL #4111](https://github.com/PDAL/PDAL/pull/4111)