### PR TITLE
az.cpp: replace std::cbegin and std::cend

### DIFF
--- a/arbiter/drivers/az.cpp
+++ b/arbiter/drivers/az.cpp
@@ -270,7 +270,7 @@ std::unique_ptr<std::size_t> AZ::tryGetSize(
     if (m_config->hasSasToken())
     {
         Query q = m_config->sasToken();
-        q.insert(query.cbegin(), query.cend());
+        q.insert(std::begin(query), std::end(query));
         res.reset(new Response(http.internalHead(resource.url(), headers, q)));
     }
     else

--- a/arbiter/drivers/az.cpp
+++ b/arbiter/drivers/az.cpp
@@ -270,7 +270,7 @@ std::unique_ptr<std::size_t> AZ::tryGetSize(
     if (m_config->hasSasToken())
     {
         Query q = m_config->sasToken();
-        q.insert(std::cbegin(query),std::cend(query));
+        q.insert(query.cbegin(), query.cend());
         res.reset(new Response(http.internalHead(resource.url(), headers, q)));
     }
     else


### PR DESCRIPTION
Breaks C++11 compatibility. These are only available in C++14 and later. 