### PR TITLE
Add Linux and Mac CI support for Arbiter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,6 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: brew install openssl curl
 
-    - name: Install dependencies on Windows
-      if: matrix.os == 'windows-latest'
-      run: choco install openssl curl
-
     - name: CMake create build folder
       run: cmake -E make_directory build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: Build Arbiter
+
+on:
+  - push
+  - pull_request
+  - workflow_dispatch
+
+jobs:
+  build-and-test:
+    name: Testing on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies on Ubuntu
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get update && sudo apt-get install -y libssl-dev libcurl4-openssl-dev
+
+    - name: Install dependencies on MacOS
+      if: matrix.os == 'macos-latest'
+      run: brew install openssl curl
+
+    - name: Install dependencies on Windows
+      if: matrix.os == 'windows-latest'
+      run: choco install openssl curl
+
+    - name: CMake create build folder
+      run: cmake -E make_directory build
+
+    - name: CMake setup
+      run: cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DCMAKE_VERBOSE_MAKEFILE=ON
+      working-directory: build
+
+    - name: CMake build
+      run: cmake --build . --config Release
+      working-directory: build
+
+    - name: CMake install
+      run: cmake --build . --config Release --target install
+      working-directory: build
+
+    - name: CMake test
+      run: cmake --build . --config Release --target test
+      working-directory: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -25,25 +25,21 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: brew install openssl curl
 
-    - name: Install dependencies on Windows
-      if: matrix.os == 'windows-latest'
-      run: choco install curl --params "/WinSSL /C /F" -y
-
     - name: CMake create build folder
       run: cmake -E make_directory build
 
     - name: CMake setup
-      run: cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DCMAKE_VERBOSE_MAKEFILE=ON
+      run: cmake .. -DCMAKE_INSTALL_PREFIX=install -DCMAKE_VERBOSE_MAKEFILE=ON
       working-directory: build
 
     - name: CMake build
-      run: cmake --build . --config Release
+      run: cmake --build .
       working-directory: build
 
     - name: CMake install
-      run: cmake --build . --config Release --target install
+      run: cmake --build . --target install
       working-directory: build
 
     - name: CMake test
-      run: cmake --build . --config Release --target test
+      run: cmake --build . --target test
       working-directory: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       run: brew install openssl curl
 
     - name: Install dependencies on Windows
+      if: matrix.os == 'windows-latest'
       run: choco install curl --params "/WinSSL /C /F" -y
 
     - name: CMake create build folder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: brew install openssl curl
 
+    - name: Install dependencies on Windows
+      run: choco install curl --params "/WinSSL /C /F" -y
+
     - name: CMake create build folder
       run: cmake -E make_directory build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU OR
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
     add_definitions("-DWINDOWS")
     add_definitions("-D_CRT_SECURE_NO_WARNINGS")
-    find_library(SHLWAPI Shlwapi)
+    find_library(SHLWAPI Shlwapi.lib)
 endif()
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
@@ -78,3 +78,4 @@ include_directories(src third/gtest-1.7.0/include third/gtest-1.7.0)
 add_subdirectory(test)
 
 install(TARGETS arbiter DESTINATION lib)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU OR
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
     add_definitions("-DWINDOWS")
     add_definitions("-D_CRT_SECURE_NO_WARNINGS")
-    find_library(SHLWAPI Shlwapi.lib)
+    find_library(SHLWAPI Shlwapi)
 endif()
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
@@ -78,4 +78,3 @@ include_directories(src third/gtest-1.7.0/include third/gtest-1.7.0)
 add_subdirectory(test)
 
 install(TARGETS arbiter DESTINATION lib)
-


### PR DESCRIPTION
Hello, as commented in the PR #51, in this new PR I bring the support for CI here.

You check the current CI result in https://github.com/uilianries/arbiter/actions/runs/8003322889

For now, only Linux and Mac are running. The CI fail to build on Windows, can not find libcurl and Shlwapi, so we can re-visit it later.