### PR TITLE
Implements AssumeRoleWithWebIdentity

### DIFF
--- a/arbiter/drivers/s3.hpp
+++ b/arbiter/drivers/s3.hpp
@@ -22,6 +22,12 @@ namespace arbiter
 namespace drivers
 {
 
+enum class ReauthMethod {
+    ASSUME_ROLE_WITH_WEB_IDENTITY,
+    IMDS_V1,
+    IMDS_V2,
+};
+
 /** @brief Amazon %S3 driver. */
 class S3 : public Http
 {
@@ -42,6 +48,7 @@ public:
      *      - JSON configuration
      *      - Well-known files or their environment overrides, like
      *          `~/.aws/credentials` or the file at AWS_CREDENTIAL_FILE.
+     *      - STS assume role with web identity.
      *      - EC2 instance profile.
      */
     static std::unique_ptr<S3> create(
@@ -113,9 +120,9 @@ public:
         , m_token(token)
     { }
 
-    Auth(std::string credUrl, bool imdsv2 = true)
+    Auth(std::string credUrl, ReauthMethod reauthMethod)
         : m_credUrl(internal::makeUnique<std::string>(credUrl))
-        , m_imdsv2(imdsv2)
+        , m_reauthMethod(reauthMethod)
     { }
 
     static std::unique_ptr<Auth> create(std::string profile, std::string s);
@@ -128,7 +135,7 @@ private:
     mutable std::string m_token;
 
     std::unique_ptr<std::string> m_credUrl;
-    bool m_imdsv2 = true;
+    ReauthMethod m_reauthMethod;
     mutable std::unique_ptr<Time> m_expiration;
     mutable std::mutex m_mutex;
 };
@@ -151,6 +158,8 @@ private:
     const std::string m_baseUrl;
     http::Headers m_baseHeaders;
     bool m_precheck;
+
+    friend class S3;
 };
 
 


### PR DESCRIPTION
Fixes #54

This will no doubt need some tidying up - code formatting, unit tests - but thought I would PR already to see if you
are happy with this change in principle, and if it's heading in the right direction.

Steps taken are the same as in GDAL:

Before trying IMDS, but after all other types of auth,
- see if AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE are set
- if so, load the AWS_WEB_IDENTITY_TOKEN_FILE
- use it to construct an STS AssumeRoleWithWebIdentity URL
- use that URL in a similar manner to the other token-issuing URLs
- except that the response is XML, not JSON

TESTED=tried out manually on an EC2 cluster using IRSA (IAM Roles for Service Accounts)

TODO: write unit tests