### PR TITLE
Use curl multi interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,7 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-
-find_package(CURL)
-if (CURL_FOUND)
-    message("Found curl")
-    find_package(Threads REQUIRED)
-    include_directories(${CURL_INCLUDE_DIRS})
-    set(ARBITER_CURL TRUE)
-    add_definitions("-DARBITER_CURL")
-else()
-    message("Curl NOT found")
-endif()
+find_package(CURL REQUIRED)
 
 find_package(OpenSSL 1.0)
 if (OPENSSL_FOUND)
@@ -31,11 +21,12 @@ endif()
 
 MESSAGE(${CMAKE_CXX_COMPILER_ID})
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU OR
-        ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+        ${CMAKE_CXX_COMPILER_ID} MATCHES ".*Clang")
     add_definitions("-DUNIX")
     add_definitions(${CMAKE_CXX_FLAGS} "-Wno-deprecated-declarations")
+    add_definitions(${CMAKE_CXX_FLAGS} "-Werror")
     add_definitions(${CMAKE_CXX_FLAGS} "-Wall")
-    add_definitions(${CMAKE_CXX_FLAGS} "-pedantic")
+    add_definitions(${CMAKE_CXX_FLAGS} "-Wextra")
     add_definitions(${CMAKE_CXX_FLAGS} "-pthread")
     add_definitions(${CMAKE_CXX_FLAGS} "-fexceptions")
     add_definitions(${CMAKE_CXX_FLAGS} "-fPIC")
@@ -46,8 +37,6 @@ elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
 endif()
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
-
-
 
 add_subdirectory(arbiter)
 
@@ -63,10 +52,8 @@ if (${ARBITER_ZLIB})
     target_include_directories(arbiter PRIVATE "${ZLIB_INCLUDE_DIR}")
 endif()
 
-if (${ARBITER_CURL})
-	target_link_libraries(arbiter PUBLIC ${CURL_LIBRARIES})
-    target_include_directories(arbiter PRIVATE "${CURL_INCLUDE_DIR}")
-endif()
+target_link_libraries(arbiter PUBLIC ${CURL_LIBRARIES})
+target_include_directories(arbiter PRIVATE "${CURL_INCLUDE_DIR}")
 
 if (${ARBITER_OPENSSL})
     target_link_libraries(arbiter PUBLIC ${OPENSSL_LIBRARIES})
@@ -76,6 +63,11 @@ endif()
 target_link_libraries(arbiter PUBLIC ${SHLWAPI})
 
 include (${CMAKE_SOURCE_DIR}/cmake/gtest.cmake)
+
+add_executable(arb
+    cmdline/cmdline.cpp)
+target_link_libraries(arb PRIVATE arbiter)
+target_include_directories(arb PRIVATE arbiter)
 
 add_subdirectory(test)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if (${ARBITER_ZLIB})
 endif()
 
 target_link_libraries(arbiter PUBLIC ${CURL_LIBRARIES})
-target_include_directories(arbiter PRIVATE "${CURL_INCLUDE_DIR}")
+target_include_directories(arbiter PRIVATE ${CURL_INCLUDE_DIR})
 
 if (${ARBITER_OPENSSL})
     target_link_libraries(arbiter PUBLIC ${OPENSSL_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -95,5 +95,5 @@ Once the amalgamated files are integrated with your source tree, simply `#includ
 
 Arbiter depends on [Curl](http://curl.haxx.se/libcurl/), which comes preinstalled on most UNIX-based machines.  To manually link (for amalgamated usage) on Unix-based operating systems, link with `-lcurl`.  Arbiter also works on Windows, but you'll have to obtain Curl yourself there.
 
-Arbiter requires C++11.
+Arbiter requires C++17.
 

--- a/amalgamate.py
+++ b/amalgamate.py
@@ -102,12 +102,6 @@ def amalgamate_source(source_top_dir=None,
         header.add_file("arbiter/third/xml/rapidxml.hpp")
         header.add_file("arbiter/third/xml/xml.hpp")
 
-    if define_curl:
-        header.add_text("\n#pragma once")
-        header.add_text("#define ARBITER_CURL")
-    else:
-        print("NOT #defining ARBITER_CURL")
-
     if bundle_json:
         header.add_file("arbiter/third/json/json.hpp")
     else:

--- a/arbiter/arbiter.cpp
+++ b/arbiter/arbiter.cpp
@@ -24,10 +24,8 @@ namespace
 {
     const std::string delimiter("://");
 
-#ifdef ARBITER_CURL
     const std::size_t concurrentHttpReqs(32);
     const std::size_t httpRetryCount(8);
-#endif
 
     json getConfig(const std::string& s)
     {
@@ -52,14 +50,12 @@ Arbiter::Arbiter() : Arbiter("") { }
 
 Arbiter::Arbiter(const std::string s)
     : m_config(s)
-#ifdef ARBITER_CURL
     , m_pool(
             new http::Pool(
                 concurrentHttpReqs,
                 httpRetryCount,
                 getConfig(s).dump()))
-#endif
-{ }
+{}
 
 void Arbiter::addDriver(const std::string type, std::shared_ptr<Driver> driver)
 {
@@ -330,7 +326,7 @@ std::shared_ptr<drivers::Http> Arbiter::getHttpDriver(const std::string path) co
 
 LocalHandle Arbiter::getLocalHandle(
         const std::string path,
-        const Endpoint& tempEndpoint) const
+        const Endpoint& /*tempEndpoint*/) const
 {
     const Endpoint fromEndpoint(getEndpoint(getDirname(path)));
     return fromEndpoint.getLocalHandle(getBasename(path));

--- a/arbiter/driver.cpp
+++ b/arbiter/driver.cpp
@@ -29,7 +29,6 @@ std::shared_ptr<Driver> Driver::create(
 
     if (type == "file") return Fs::create();
     if (type == "test") return Test::create();
-#ifdef ARBITER_CURL
     if (type == "http") return Http::create(pool);
     if (type == "https") return Https::create(pool);
     if (type == "s3") return S3::create(pool, entry.dump(), profile);
@@ -37,7 +36,6 @@ std::shared_ptr<Driver> Driver::create(
     if (type == "dbx") return Dropbox::create(pool, entry.dump(), profile);
 #ifdef ARBITER_OPENSSL
     if (type == "gs") return Google::create(pool, entry.dump(), profile);
-#endif
 #endif
     return std::shared_ptr<Driver>();
 }
@@ -123,7 +121,7 @@ std::vector<std::string> Driver::resolve(
     return results;
 }
 
-std::vector<std::string> Driver::glob(std::string path, bool verbose) const
+std::vector<std::string> Driver::glob(std::string path, bool /*verbose*/) const
 {
     throw ArbiterError("Cannot glob driver for: " + path);
 }

--- a/arbiter/drivers/az.cpp
+++ b/arbiter/drivers/az.cpp
@@ -46,15 +46,18 @@ namespace
 
     std::string makeLower(const std::string& in)
     {
-        return std::accumulate(
-                in.begin(),
-                in.end(),
-                std::string(),
-                [](const std::string& out, const char c) -> std::string
-                {
-                    return out + static_cast<char>(::tolower(c));
-                });
+        std::string out;
+        for (char c : in)
+            out += (char)std::tolower(c);
+        return out;
     }
+
+    std::string extractBaseUrl(const std::string& service, const std::string& endpoint,
+        const std::string& account)
+    {
+        return account + "." + service + "." + endpoint + "/";
+    }
+
 }
 
 namespace drivers
@@ -88,7 +91,7 @@ AZ::Config::Config(const std::string s)
     , m_storageAccount(extractStorageAccount(s))
     , m_storageAccessKey(extractStorageAccessKey(s))
     , m_endpoint(extractEndpoint(s))
-    , m_baseUrl(extractBaseUrl(s, m_service, m_endpoint, m_storageAccount))
+    , m_baseUrl(extractBaseUrl(m_service, m_endpoint, m_storageAccount))
 {
     const std::string sasString = extractSasToken(s);
     if (!sasString.empty())
@@ -247,18 +250,9 @@ std::string AZ::Config::extractEndpoint(const std::string s)
     return "core.windows.net";
 }
 
-std::string AZ::Config::extractBaseUrl(
-     const std::string s,
-     const std::string service,
-     const std::string endpoint,
-     const std::string account)
-{
-    return account + "." + service + "." + endpoint + "/";
-}
-
 std::unique_ptr<std::size_t> AZ::tryGetSize(
     const std::string rawPath,
-    const http::Headers userHeaders,
+    const http::Headers /*userHeaders*/,
     const http::Query query) const
 {
     Headers headers(m_config->baseHeaders());

--- a/arbiter/drivers/az.hpp
+++ b/arbiter/drivers/az.hpp
@@ -111,7 +111,6 @@ public:
 private:
     static std::string extractService(std::string j);
     static std::string extractEndpoint(std::string j);
-    static std::string extractBaseUrl(std::string j, std::string endpoint, std::string service, std::string account);
     static std::string extractStorageAccount(std::string j);
     static std::string extractStorageAccessKey(std::string j);
     static std::string extractSasToken(std::string j);

--- a/arbiter/drivers/dropbox.cpp
+++ b/arbiter/drivers/dropbox.cpp
@@ -147,20 +147,21 @@ bool Dropbox::get(
     headers["Dropbox-API-Arg"] = json{{ "path", "/" + path }}.dump();
     headers.insert(userHeaders.begin(), userHeaders.end());
 
-    const Response res(Http::internalGet(getUrl, headers, query));
+    Response res(Http::internalGet(getUrl, headers, query));
 
     if (res.ok())
     {
         if (!userHeaders.count("Range"))
         {
-            if (!res.headers().count("dropbox-api-result"))
+            Headers headers = res.headers();
+            if (!headers.count("dropbox-api-result"))
             {
                 std::cout << "No dropbox-api-result header found" << std::endl;
                 return false;
             }
 
             json rx;
-            try { rx = json::parse(res.headers().at("dropbox-api-result")); }
+            try { rx = json::parse(headers.at("dropbox-api-result")); }
             catch (...) { std::cout << "Failed to parse result" << std::endl; }
 
             if (!rx.is_null())
@@ -215,9 +216,10 @@ std::vector<char> Dropbox::put(
 
     headers.insert(userHeaders.begin(), userHeaders.end());
 
-    const Response res(Http::internalPost(putUrl, data, headers, query));
+    Response res(Http::internalPost(putUrl, data, headers, query));
 
-    if (!res.ok()) throw ArbiterError(res.str());
+    if (!res.ok())
+        throw ArbiterError(res.str());
     return res.data();
 }
 

--- a/arbiter/drivers/fs.cpp
+++ b/arbiter/drivers/fs.cpp
@@ -148,7 +148,7 @@ void Fs::copy(std::string src, std::string dst) const
     outstream << instream.rdbuf();
 }
 
-std::vector<std::string> Fs::glob(std::string path, bool verbose) const
+std::vector<std::string> Fs::glob(std::string path, bool /*verbose*/) const
 {
     return arbiter::glob(path);
 }

--- a/arbiter/drivers/google.cpp
+++ b/arbiter/drivers/google.cpp
@@ -116,8 +116,7 @@ std::unique_ptr<std::size_t> Google::tryGetSize(const std::string path) const
     const GResource resource(path);
 
     drivers::Https https(m_pool);
-    const auto res(
-            https.internalHead(resource.endpoint(), headers, altMediaQuery));
+    http::Response res(https.internalHead(resource.endpoint(), headers, altMediaQuery));
 
     if (res.ok())
     {
@@ -132,14 +131,14 @@ bool Google::get(
         const std::string path,
         std::vector<char>& data,
         const http::Headers userHeaders,
-        const http::Query query) const
+        const http::Query /*query*/) const
 {
     http::Headers headers(m_auth->headers());
     headers.insert(userHeaders.begin(), userHeaders.end());
     const GResource resource(path);
 
     drivers::Https https(m_pool);
-    const auto res(
+    http::Response res(
             https.internalGet(resource.endpoint(), headers, altMediaQuery));
 
     if (res.ok())
@@ -173,12 +172,13 @@ std::vector<char> Google::put(
     query["name"] = http::sanitize(resource.object(), GResource::exclusions);
 
     drivers::Https https(m_pool);
-    const auto res(https.internalPost(url, data, headers, query));
-    if (!res.ok()) throw ArbiterError(res.str());
+    http::Response res(https.internalPost(url, data, headers, query));
+    if (!res.ok())
+        throw ArbiterError(res.str());
     return res.data();
 }
 
-std::vector<std::string> Google::glob(std::string path, bool verbose) const
+std::vector<std::string> Google::glob(std::string path, bool /*verbose*/) const
 {
     std::vector<std::string> results;
 
@@ -203,12 +203,10 @@ std::vector<std::string> Google::glob(std::string path, bool verbose) const
     {
         if (pageToken.size()) query["pageToken"] = pageToken;
 
-        const auto res(https.internalGet(url, m_auth->headers(), query));
+        http::Response res(https.internalGet(url, m_auth->headers(), query));
 
         if (!res.ok())
-        {
             throw ArbiterError(std::to_string(res.code()) + ": " + res.str());
-        }
 
         const json j(json::parse(res.str()));
         for (const json& item : j.at("items"))
@@ -309,7 +307,7 @@ void Google::Auth::maybeRefresh() const
 
     http::Pool pool;
     drivers::Https https(pool);
-    const auto res(https.internalPost(tokenRequestUrl, body, headers));
+    http::Response res(https.internalPost(tokenRequestUrl, body, headers));
 
     if (!res.ok())
     {

--- a/arbiter/drivers/http.cpp
+++ b/arbiter/drivers/http.cpp
@@ -37,11 +37,7 @@ Http::Http(
     : Driver(driverProtocol, profile)
     , m_pool(pool)
     , m_httpProtocol(httpProtocol)
-{
-#ifndef ARBITER_CURL
-    throw ArbiterError("Cannot create HTTP driver - no curl support was built");
-#endif
-}
+{}
 
 std::unique_ptr<Http> Http::create(Pool& pool)
 {
@@ -150,17 +146,11 @@ bool Http::get(
         const Headers headers,
         const Query query) const
 {
-    bool good(false);
-
-    auto http(m_pool.acquire());
+    Resource http(m_pool.acquire());
     Response res(http.get(typedPath(path), headers, query));
 
-
     data = res.data();
-    if (res.ok())
-        good = true;
-
-    return good;
+    return res.ok();
 }
 
 std::vector<char> Http::put(
@@ -169,8 +159,8 @@ std::vector<char> Http::put(
         const Headers headers,
         const Query query) const
 {
-    auto http(m_pool.acquire());
-    auto res(http.put(typedPath(path), data, headers, query));
+    Resource http(m_pool.acquire());
+    Response res(http.put(typedPath(path), data, headers, query));
 
     if (!res.ok())
     {
@@ -195,8 +185,8 @@ void Http::post(
         const Headers headers,
         const Query query) const
 {
-    auto http(m_pool.acquire());
-    auto res(http.post(typedPath(path), data, headers, query));
+    Resource http(m_pool.acquire());
+    Response res(http.post(typedPath(path), data, headers, query));
 
     if (!res.ok())
     {

--- a/arbiter/drivers/s3.cpp
+++ b/arbiter/drivers/s3.cpp
@@ -38,11 +38,9 @@ using namespace internal;
 
 namespace
 {
-#ifdef ARBITER_CURL
     // Re-fetch credentials when there are less than 4 minutes remaining.  New
     // ones are guaranteed by AWS to be available within 5 minutes remaining.
     constexpr int64_t reauthSeconds(60 * 4);
-#endif
 
     // See:
     // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
@@ -218,7 +216,6 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
         }
     }
 
-#ifdef ARBITER_CURL
     http::Pool pool;
     drivers::Http httpDriver(pool);
 
@@ -283,7 +280,7 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
             // which only support v1, this request will fail.  That's ok, the
             // next request looks the same anyway (except without the token of
             // course), and that corresponds to the IMDSv1 flow as a fallback.
-            const auto res = httpDriver.internalPut(
+            auto res = httpDriver.internalPut(
                 ec2TokenBase,
                 std::vector<char>(),
                 {{ "X-aws-ec2-metadata-token-ttl-seconds", "21600" }},
@@ -294,15 +291,14 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
 
             if (!res.ok()) throw ArbiterError("Failed to get IMDSv2 token");
 
-            const auto tokenvec = res.data();
-            token = std::string(tokenvec.data(), tokenvec.size());
+            token = res.str();
         }
         catch (...) { }
 
         http::Headers headers;
         if (!token.empty()) headers["X-aws-ec2-metadata-token"] = token;
 
-        const auto res = httpDriver.internalGet(
+        auto res = httpDriver.internalGet(
             ec2CredBase,
             headers,
             {{ }},
@@ -311,8 +307,7 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
             1);
         if (!res.ok()) throw ArbiterError("Failed to get IAM role");
 
-        const auto rolevec = res.data();
-        const auto iamRole = std::string(rolevec.begin(), rolevec.end());
+        std::string iamRole = res.str();
 
         if (!iamRole.empty())
         {
@@ -328,7 +323,6 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
     {
         return makeUnique<Auth>(fargateCredIp + "/" + *relUri, ReauthMethod::IMDS_V2);
     }
-#endif
 
     return std::unique_ptr<Auth>();
 }
@@ -482,7 +476,6 @@ std::string S3::Config::extractBaseUrl(
 
 S3::AuthFields S3::Auth::fields() const
 {
-#ifdef ARBITER_CURL
     if (m_credUrl)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -499,7 +492,7 @@ S3::AuthFields S3::Auth::fields() const
             {
                 try
                 {
-                    const auto res = httpDriver.internalPut(
+                    Response res = httpDriver.internalPut(
                         ec2TokenBase,
                         std::vector<char>(),
                         {{ "X-aws-ec2-metadata-token-ttl-seconds", "21600" }},
@@ -512,8 +505,7 @@ S3::AuthFields S3::Auth::fields() const
                         throw ArbiterError("Failed to get IMDSv2 token");
                     }
 
-                    const auto tokenvec = res.data();
-                    token = std::string(tokenvec.data(), tokenvec.size());
+                    token = res.str();
                 }
                 catch (...) { }
             }
@@ -521,12 +513,13 @@ S3::AuthFields S3::Auth::fields() const
             http::Headers headers;
             if (!token.empty()) headers["X-aws-ec2-metadata-token"] = token;
 
-            const auto res = httpDriver.internalGet(*m_credUrl, headers);
+            Response res = httpDriver.internalGet(*m_credUrl, headers);
             if (!res.ok())
             {
                 throw ArbiterError("Failed to get token");
             }
-            std::vector<char> data(res.data());
+
+            std::vector<char> data = res.data();
             data.push_back('\0');
 
             if (m_reauthMethod == ReauthMethod::ASSUME_ROLE_WITH_WEB_IDENTITY)
@@ -593,7 +586,6 @@ S3::AuthFields S3::Auth::fields() const
         // releasing the lock.
         return S3::AuthFields(m_access, m_hidden, m_token);
     }
-#endif
 
     return S3::AuthFields(m_access, m_hidden, m_token);
 }

--- a/arbiter/util/CMakeLists.txt
+++ b/arbiter/util/CMakeLists.txt
@@ -33,11 +33,10 @@ if (WIN32)
     set_target_properties(${MODULE}
         PROPERTIES
             COMPILE_DEFINITIONS ARBITER_DLL_EXPORT)
-    target_include_directories(util PRIVATE "${CURL_INCLUDE_DIR}")
-
 else()
     add_library(${MODULE} OBJECT ${SOURCES})
 endif()
+target_include_directories(${MODULE} PRIVATE "${CURL_INCLUDE_DIR}")
 
 install(FILES ${HEADERS} DESTINATION include/arbiter/${MODULE})
 

--- a/arbiter/util/curl.cpp
+++ b/arbiter/util/curl.cpp
@@ -240,6 +240,7 @@ void Curl::prepareGet(
     // Set up callback and data pointer for received headers.
     curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, Response::headerCb);
     curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &m_response);
+}
 
 void Curl::prepareHead(
     std::string path,

--- a/arbiter/util/curl.cpp
+++ b/arbiter/util/curl.cpp
@@ -10,9 +10,7 @@
 #include <arbiter/util/json.hpp>
 #endif
 
-#ifdef ARBITER_CURL
 #include <curl/curl.h>
-#endif
 
 #ifdef ARBITER_CUSTOM_NAMESPACE
 namespace ARBITER_CUSTOM_NAMESPACE
@@ -27,84 +25,8 @@ using namespace internal;
 namespace http
 {
 
-namespace
+Curl::Curl(std::size_t id, const std::string& s) : m_id(id)
 {
-#ifdef ARBITER_CURL
-    struct PutData
-    {
-        PutData(const std::vector<char>& data)
-            : data(data)
-            , offset(0)
-        { }
-
-        const std::vector<char>& data;
-        std::size_t offset;
-    };
-
-    std::size_t getCb(
-            const char* in,
-            std::size_t size,
-            std::size_t num,
-            std::vector<char>* out)
-    {
-        const std::size_t fullBytes(size * num);
-        const std::size_t startSize(out->size());
-
-        out->resize(out->size() + fullBytes);
-        std::memcpy(out->data() + startSize, in, fullBytes);
-
-        return fullBytes;
-    }
-
-    std::size_t putCb(
-            char* out,
-            std::size_t size,
-            std::size_t num,
-            PutData* in)
-    {
-        const std::size_t fullBytes(
-                (std::min)(
-                    size * num,
-                    in->data.size() - in->offset));
-        std::memcpy(out, in->data.data() + in->offset, fullBytes);
-
-        in->offset += fullBytes;
-        return fullBytes;
-    }
-
-    std::size_t headerCb(
-            const char *buffer,
-            std::size_t size,
-            std::size_t num,
-            http::Headers* out)
-    {
-        const std::size_t fullBytes(size * num);
-
-        std::string data(buffer, fullBytes);
-        data.erase(std::remove(data.begin(), data.end(), '\n'), data.end());
-        data.erase(std::remove(data.begin(), data.end(), '\r'), data.end());
-
-        const std::size_t split(data.find_first_of(":"));
-
-        // No colon means it isn't a header with data.
-        if (split == std::string::npos) return fullBytes;
-
-        const std::string key(data.substr(0, split));
-        const std::string val(data.substr(split + 1, data.size()));
-
-        (*out)[key] = val;
-
-        return fullBytes;
-    }
-
-#else
-    const std::string fail("Arbiter was built without curl");
-#endif // ARBITER_CURL
-} // unnamed namespace
-
-Curl::Curl(const std::string s)
-{
-#ifdef ARBITER_CURL
     const json c(s.size() ? json::parse(s) : json::object());
 
     m_curl = curl_easy_init();
@@ -210,24 +132,40 @@ Curl::Curl(const std::string s)
             "\n\tProxy: " << (m_proxy ? *m_proxy : "(default)") <<
             std::endl;
     }
-#endif
 }
 
 Curl::~Curl()
 {
-#ifdef ARBITER_CURL
-    curl_easy_cleanup(m_curl);
-    curl_slist_free_all(m_headers);
-    m_headers = nullptr;
-#endif
+    if (m_curl)
+        curl_easy_cleanup(m_curl);
+    if (m_headers)
+        curl_slist_free_all(m_headers);
+}
+
+// The only time this should be invoked is when things are moving in a vector of Curls.
+Curl::Curl(Curl&& other)
+{
+    m_curl = other.m_curl; other.m_curl = nullptr;
+    m_headers = other.m_headers; other.m_headers = nullptr;
+    m_id = other.m_id;
+    m_code = other.m_code;
+    m_state = other.m_state; other.m_state = State::UNUSED;
+    m_verbose = other.m_verbose;
+    m_timeout = other.m_timeout;
+    m_followRedirect = other.m_followRedirect;
+    m_verifyPeer = other.m_verifyPeer;
+    m_caPath = std::move(other.m_caPath);
+    m_caInfo = std::move(other.m_caInfo);
+    m_proxy = std::move(other.m_proxy);
+    m_response = std::move(other.m_response);
+    m_putData = std::move(other.m_putData);
 }
 
 void Curl::init(
-        const std::string rawPath,
+        const std::string& rawPath,
         const Headers& headers,
         const Query& query)
 {
-#ifdef ARBITER_CURL
     // Reset our curl instance and header list.
     curl_slist_free_all(m_headers);
     m_headers = nullptr;
@@ -278,143 +216,85 @@ void Curl::init(
                 m_headers,
                 (h.first + ": " + h.second).c_str());
     }
-#else
-    throw ArbiterError(fail);
-#endif
 }
 
-int Curl::perform()
-{
-#ifdef ARBITER_CURL
-    long httpCode(0);
-
-    const auto code(curl_easy_perform(m_curl));
-    curl_easy_getinfo(m_curl, CURLINFO_RESPONSE_CODE, &httpCode);
-    curl_easy_reset(m_curl);
-
-    if (code != CURLE_OK)
-    {
-        if (m_verbose)
-        {
-            std::cout << "Curl failure: " << curl_easy_strerror(code) << 
-                std::endl;
-        }
-        httpCode = 550;
-    }
-
-    return httpCode;
-#else
-    throw ArbiterError(fail);
-#endif
-}
-
-Response Curl::get(
+void Curl::prepareGet(
         std::string path,
         Headers headers,
         Query query,
         const std::size_t reserve,
         const std::size_t timeout)
 {
-#ifdef ARBITER_CURL
-    std::vector<char> data;
-
-    if (reserve) data.reserve(reserve);
+    m_response.init(reserve);
 
     init(path, headers, query);
     if (timeout) curl_easy_setopt(m_curl, CURLOPT_LOW_SPEED_TIME, timeout);
 
     // Register callback function and data pointer to consume the result.
-    curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, getCb);
-    curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &data);
+    curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, Response::getCb);
+    curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &m_response);
 
     // Insert all headers into the request.
     curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, m_headers);
 
     // Set up callback and data pointer for received headers.
-    Headers receivedHeaders;
-    curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, headerCb);
-    curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &receivedHeaders);
+    curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, Response::headerCb);
+    curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &m_response);
 
-    // Run the command.
-    const int httpCode(perform());
-
-    for (auto& h : receivedHeaders)
-    {
-        std::string& v(h.second);
-        while (v.size() && v.front() == ' ') v = v.substr(1);
-        while (v.size() && v.back() == ' ') v.pop_back();
-    }
-
-    return Response(httpCode, data, receivedHeaders);
-#else
-    throw ArbiterError(fail);
-#endif
-}
-
-Response Curl::head(
+void Curl::prepareHead(
     std::string path,
     Headers headers,
     Query query,
     const std::size_t timeout)
 {
-#ifdef ARBITER_CURL
-    std::vector<char> data;
+    m_response.init();
 
     init(path, headers, query);
-    if (timeout) curl_easy_setopt(m_curl, CURLOPT_LOW_SPEED_TIME, timeout);
+    if (timeout)
+        curl_easy_setopt(m_curl, CURLOPT_LOW_SPEED_TIME, timeout);
 
     // Register callback function and data pointer to consume the result.
-    curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, getCb);
-    curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &data);
+    curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, Response::getCb);
+    curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &m_response);
 
     // Insert all headers into the request.
     curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, m_headers);
 
     // Set up callback and data pointer for received headers.
-    Headers receivedHeaders;
-    curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, headerCb);
-    curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &receivedHeaders);
+    curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, Response::headerCb);
+    curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &m_response);
 
     // Specify a HEAD request.
     curl_easy_setopt(m_curl, CURLOPT_NOBODY, 1L);
-
-    // Run the command.
-    const int httpCode(perform());
-    return Response(httpCode, data, receivedHeaders);
-#else
-    throw ArbiterError(fail);
-#endif
 }
 
-Response Curl::put(
+void Curl::preparePut(
         std::string path,
         const std::vector<char>& data,
         Headers headers,
         Query query,
         const std::size_t timeout)
 {
-#ifdef ARBITER_CURL
+    m_response.init();
+    m_putData.init(data);
     init(path, headers, query);
     if (timeout) curl_easy_setopt(m_curl, CURLOPT_LOW_SPEED_TIME, timeout);
 
-    std::unique_ptr<PutData> putData(new PutData(data));
-    std::vector<char> writeData;
 
     // Register callback function and data pointer to create the request.
-    curl_easy_setopt(m_curl, CURLOPT_READFUNCTION, putCb);
-    curl_easy_setopt(m_curl, CURLOPT_READDATA, putData.get());
+    curl_easy_setopt(m_curl, CURLOPT_READFUNCTION, PutData::putCb);
+    curl_easy_setopt(m_curl, CURLOPT_READDATA, &m_putData);
 
     // Register callback function and data pointer to consume the result.
-    curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, getCb);
-    curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &writeData);
+    curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, Response::getCb);
+    curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &m_response);
 
     // Insert all headers into the request.
     curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, m_headers);
 
     // Set up callback and data pointer for received headers.
-    Headers receivedHeaders;
-    curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, headerCb);
-    curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &receivedHeaders);
+    curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, Response::headerCb);
+    curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &m_response);
 
     // Specify that this is a PUT request.
     curl_easy_setopt(m_curl, CURLOPT_PUT, 1L);
@@ -425,44 +305,34 @@ Response Curl::put(
             m_curl,
             CURLOPT_INFILESIZE_LARGE,
             static_cast<curl_off_t>(data.size()));
-
-    // Run the command.
-    const int httpCode(perform());
-    return Response(httpCode, writeData, receivedHeaders);
-#else
-    throw ArbiterError(fail);
-#endif
 }
 
-Response Curl::post(
+void Curl::preparePost(
         std::string path,
         const std::vector<char>& data,
         Headers headers,
         Query query,
         const std::size_t timeout)
 {
-#ifdef ARBITER_CURL
+    m_response.init();
+    m_putData.init(data);
     init(path, headers, query);
     if (timeout) curl_easy_setopt(m_curl, CURLOPT_LOW_SPEED_TIME, timeout);
 
-    std::unique_ptr<PutData> putData(new PutData(data));
-    std::vector<char> writeData;
-
     // Register callback function and data pointer to create the request.
-    curl_easy_setopt(m_curl, CURLOPT_READFUNCTION, putCb);
-    curl_easy_setopt(m_curl, CURLOPT_READDATA, putData.get());
+    curl_easy_setopt(m_curl, CURLOPT_READFUNCTION, PutData::putCb);
+    curl_easy_setopt(m_curl, CURLOPT_READDATA, &m_putData);
 
     // Register callback function and data pointer to consume the result.
-    curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, getCb);
-    curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &writeData);
+    curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, Response::getCb);
+    curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &m_response);
 
     // Insert all headers into the request.
     curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, m_headers);
 
     // Set up callback and data pointer for received headers.
-    Headers receivedHeaders;
-    curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, headerCb);
-    curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &receivedHeaders);
+    curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, Response::headerCb);
+    curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, &m_response);
 
     // Specify that this is a POST request.
     curl_easy_setopt(m_curl, CURLOPT_POST, 1L);
@@ -473,13 +343,6 @@ Response Curl::post(
             m_curl,
             CURLOPT_INFILESIZE_LARGE,
             static_cast<curl_off_t>(data.size()));
-
-    // Run the command.
-    const int httpCode(perform());
-    return Response(httpCode, writeData, receivedHeaders);
-#else
-    throw ArbiterError(fail);
-#endif
 }
 
 } // namepace http

--- a/arbiter/util/curl.cpp
+++ b/arbiter/util/curl.cpp
@@ -167,6 +167,7 @@ void Curl::init(
         const Query& query)
 {
     // Reset our curl instance and header list.
+    curl_easy_reset(m_curl);
     curl_slist_free_all(m_headers);
     m_headers = nullptr;
 

--- a/arbiter/util/curl.hpp
+++ b/arbiter/util/curl.hpp
@@ -10,11 +10,7 @@
 #include <arbiter/util/types.hpp>
 #endif
 
-#ifdef ARBITER_CURL
 #include <curl/curl.h>
-#else
-typedef void CURL;
-#endif
 
 struct curl_slist;
 
@@ -38,59 +34,75 @@ class ARBITER_DLL Curl
 
     static constexpr std::size_t defaultHttpTimeout = 5;
 
+    enum class State
+    {
+        UNUSED,     // Waiting to be used for a request.
+        ACQUIRED,   // Acquired by a Resource.
+        READY,      // Initialization complete. Ready to be run.
+        RUNNING,    // Running.
+        DONE        // Operation completed
+    };
+
 public:
+    Curl(std::size_t id, const std::string& config);
+    Curl(Curl&& curl);
     ~Curl();
 
-    http::Response get(
+    void prepareGet(
             std::string path,
             Headers headers,
             Query query,
             std::size_t reserve,
             std::size_t timeout = 0);
 
-    http::Response head(
+    void prepareHead(
             std::string path,
             Headers headers,
             Query query,
             std::size_t timeout = 0);
 
-    http::Response put(
+    void preparePut(
             std::string path,
             const std::vector<char>& data,
             Headers headers,
             Query query,
             std::size_t timeout = 0);
 
-    http::Response post(
+    void preparePost(
             std::string path,
             const std::vector<char>& data,
             Headers headers,
             Query query,
             std::size_t timeout = 0);
+
+    // Note that the response is *moved*.
+    Response response()
+    {
+        m_response.setCode(m_code);
+        return std::move(m_response);
+    }
+
+    std::size_t id() const
+    { return m_id; }
 
 private:
-    Curl(std::string j);
-
-    void init(std::string path, const Headers& headers, const Query& query);
-
-    // Returns HTTP status code.
-    int perform();
-
-    Curl(const Curl&);
-    Curl& operator=(const Curl&);
+    void init(const std::string& path, const Headers& headers, const Query& query);
 
     CURL* m_curl = nullptr;
     curl_slist* m_headers = nullptr;
 
+    std::size_t m_id;
+    State m_state = State::UNUSED;
     bool m_verbose = false;
     long m_timeout = defaultHttpTimeout;
     bool m_followRedirect = true;
     bool m_verifyPeer = true;
+    int m_code = 0;
     std::unique_ptr<std::string> m_caPath;
     std::unique_ptr<std::string> m_caInfo;
     std::unique_ptr<std::string> m_proxy;
-
-    std::vector<char> m_data;
+    Response m_response;
+    PutData m_putData;
 };
 
 /** @endcond */

--- a/arbiter/util/http.cpp
+++ b/arbiter/util/http.cpp
@@ -3,9 +3,7 @@
 #include <arbiter/util/json.hpp>
 #endif
 
-#ifdef ARBITER_CURL
 #include <curl/curl.h>
-#endif
 
 #include <cctype>
 #include <chrono>
@@ -26,17 +24,25 @@ namespace arbiter
 namespace http
 {
 
-std::string sanitize(const std::string path, const std::string excStr)
+std::string sanitize(const std::string& path, const std::string& excStr)
 {
-    static const std::set<char> unreserved = { '-', '.', '_', '~' };
-    const std::set<char> exclusions(excStr.begin(), excStr.end());
+    auto ispunct = [](char c) -> bool
+    {
+        return c == '-' || c == '.' || c == '_' || c == '~';
+    };
+
+    auto isexclusion = [&excStr](char c) -> bool
+    {
+        return excStr.find(c) != std::string::npos;
+    };
+
     std::ostringstream result;
     result.fill('0');
     result << std::hex;
 
-    for (const auto c : path)
+    for (char c : path)
     {
-        if (std::isalnum(c) || unreserved.count(c) || exclusions.count(c))
+        if (std::isalnum(c) || ispunct(c) || isexclusion(c))
         {
             result << c;
         }
@@ -54,31 +60,30 @@ std::string sanitize(const std::string path, const std::string excStr)
 
 std::string buildQueryString(const Query& query)
 {
-    return std::accumulate(
-            query.begin(),
-            query.end(),
-            std::string(),
-            [](const std::string& out, const Query::value_type& keyVal)
-            {
-                const char sep(out.empty() ? '?' : '&');
-                return out + sep + keyVal.first + '=' + keyVal.second;
-            });
+    if (query.empty())
+        return std::string();
+
+    std::string out;
+    for (auto &[key, val] : query)
+    {
+        const char sep(out.empty() ? '?' : '&');
+        out += sep + key + '=' + val;
+    }
+    return out;
 }
 
 Resource::Resource(
         Pool& pool,
         Curl& curl,
-        const std::size_t id,
         const std::size_t retry)
     : m_pool(pool)
     , m_curl(curl)
-    , m_id(id)
     , m_retry(retry)
 { }
 
 Resource::~Resource()
 {
-    m_pool.release(m_id);
+    m_pool.release(m_curl);
 }
 
 Response Resource::get(
@@ -91,7 +96,9 @@ Response Resource::get(
 {
     return exec([this, path, headers, query, reserve, timeout]()->Response
     {
-        return m_curl.get(path, headers, query, reserve, timeout);
+        m_curl.prepareGet(path, headers, query, reserve, timeout);
+        m_pool.perform(m_curl);
+        return m_curl.response();
     }, retry);
 }
 
@@ -102,7 +109,9 @@ Response Resource::head(
 {
     return exec([this, path, headers, query]()->Response
     {
-        return m_curl.head(path, headers, query);
+        m_curl.prepareHead(path, headers, query);
+        m_pool.perform(m_curl);
+        return m_curl.response();
     });
 }
 
@@ -116,7 +125,9 @@ Response Resource::put(
 {
     return exec([this, path, &data, headers, query, timeout]()->Response
     {
-        return m_curl.put(path, data, headers, query, timeout);
+        m_curl.preparePut(path, data, headers, query, timeout);
+        m_pool.perform(m_curl);
+        return m_curl.response();
     }, retry);
 }
 
@@ -128,7 +139,9 @@ Response Resource::post(
 {
     return exec([this, path, &data, headers, query]()->Response
     {
-        return m_curl.post(path, data, headers, query);
+        m_curl.preparePost(path, data, headers, query);
+        m_pool.perform(m_curl);
+        return m_curl.response();
     });
 }
 
@@ -161,53 +174,173 @@ Response Resource::exec(std::function<Response()> f, const int userRetry)
 Pool::Pool(
         const std::size_t concurrent,
         const std::size_t retry,
-        const std::string s)
-    : m_curls(concurrent)
-    , m_available(concurrent)
-    , m_retry(retry)
-    , m_mutex()
-    , m_cv()
+        const std::string& config)
+    : m_retry(retry)
 {
-#ifdef ARBITER_CURL
+    for (std::size_t i = 0; i < concurrent; ++i)
+        m_curls.emplace_back(i, config);
     curl_global_init(CURL_GLOBAL_ALL);
-
-    const json config(s.size() ? json::parse(s) : json::object());
-
-    for (std::size_t i(0); i < concurrent; ++i)
-    {
-        m_available[i] = i;
-        m_curls[i].reset(new Curl(config.dump()));
-    }
-#endif
+    m_multi = curl_multi_init();
+    m_runner = std::thread(&Pool::run, this);
 }
 
-Pool::~Pool() { }
+Pool::~Pool()
+{
+    m_stop = true;
+    wakeup();
+    m_runner.join();
 
+    std::lock_guard l(m_mutex);
+    for (size_t i = 0; i < m_curls.size(); ++i)
+        curl_multi_remove_handle(m_multi, m_curls[i].m_curl);
+
+    // This deletes all the curl objects and does curl_easy_cleanup.
+    m_curls.clear();
+    curl_multi_cleanup(m_multi);
+}
+
+// Thread that performs the curl activity. Runs until told to stop.
+void Pool::run()
+{
+    while (true)
+    {
+        // Add ready transfers to the multi handle to run.
+        handleReady();
+
+        int still_running;
+        CURLMcode result = curl_multi_perform(m_multi, &still_running);
+        if (result == CURLM_OK)
+            result = curl_multi_poll(m_multi, NULL, 0, 500, NULL);
+
+        bool notify;
+        if (result != CURLM_OK)
+            notify = handleFailure();
+        else
+            notify = handleCompleted();
+
+        // If any threads have completed, notify waiters.
+        if (notify)
+            m_poolCv.notify_all();
+        if (m_stop)
+            break;
+    }
+}
+
+// For any any transfers that are ready, set the state to running, clear the code and
+// add the handle.
+void Pool::handleReady()
+{
+    std::lock_guard l(m_mutex);
+
+    for (Curl& curl : m_curls)
+        if (curl.m_state == Curl::State::READY)
+        {
+            curl.m_state = Curl::State::RUNNING;
+            curl.m_code = 0;
+            curl_multi_add_handle(m_multi, curl.m_curl);
+        }
+}
+
+// See if any curl requests completed. If so, mark the state as DONE.
+bool Pool::handleCompleted()
+{
+    bool notify = false;
+    while (true)
+    {
+        int msgCnt;
+        CURLMsg *m = curl_multi_info_read(m_multi, &msgCnt);
+        if (!m)
+            break;
+        if (m->msg != CURLMSG_DONE)
+            continue;
+
+        // If we have a completed transfer, set the state to done, update the http code
+        // and say we should notify.
+        curl_multi_remove_handle(m_multi, m->easy_handle);
+        std::lock_guard l(m_mutex);
+        for (Curl& curl : m_curls)
+            if (curl.m_curl == m->easy_handle)
+            {
+                curl.m_state = Curl::State::DONE;
+                curl_easy_getinfo(curl.m_curl, CURLINFO_RESPONSE_CODE, &curl.m_code);
+                notify = true;
+            }
+    }
+    return notify;
+}
+
+// Abort all the running transfers as curl has failed internally. Remove the handle.
+// Set the state to done. Update the http code and return the notification state..
+bool Pool::handleFailure()
+{
+    bool notify = false;
+
+    std::lock_guard l(m_mutex);
+    for (Curl& curl : m_curls)
+        if (curl.m_state == Curl::State::RUNNING)
+        {
+            curl_multi_remove_handle(m_multi, curl.m_curl);
+            curl.m_state = Curl::State::DONE;
+            curl.m_code = 550;  // Made-up error code.
+            notify = true;
+        }
+    return notify;
+}
+
+// Wakeup the run thread.
+void Pool::wakeup()
+{
+    curl_multi_wakeup(m_multi);
+}
+
+// Acquire a resource (a curl easy handle) from the pool.
 Resource Pool::acquire()
 {
     if (m_curls.empty())
-    {
         throw std::runtime_error("Cannot acquire from empty pool");
-    }
 
+    Curl *foundCurl = nullptr;
+
+    // Wait until we find an unused Curl object. If we find one, mark
+    // it acquired.
     std::unique_lock<std::mutex> lock(m_mutex);
-    m_cv.wait(lock, [this]()->bool { return !m_available.empty(); });
+    m_cv.wait(lock, [this, &foundCurl]()
+    {
+        for (Curl& curl : m_curls)
+            if (curl.m_state == Curl::State::UNUSED)
+            {
+                curl.m_state = Curl::State::ACQUIRED;
+                foundCurl = &curl;
+                return true;
+            }
+            return false;
+     });
 
-    const std::size_t id(m_available.back());
-    Curl& curl(*m_curls[id]);
-
-    m_available.pop_back();
-
-    return Resource(*this, curl, id, m_retry);
+    // Return the resource with the acquired Curl.
+    return Resource(*this, *foundCurl, m_retry);
 }
 
-void Pool::release(const std::size_t id)
+// Release a curl handle.
+void Pool::release(Curl& curl)
 {
-    std::unique_lock<std::mutex> lock(m_mutex);
-    m_available.push_back(id);
-    lock.unlock();
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_curls[curl.id()].m_state = Curl::State::UNUSED;
+    }
 
     m_cv.notify_one();
+}
+
+void Pool::perform(Curl& curl)
+{
+    std::unique_lock l(m_mutex);
+    curl.m_state = Curl::State::READY;
+    wakeup();
+    // Wait until the operation is done or a non-recoverable error occurs.
+    m_poolCv.wait(l, [&curl]()
+    {
+        return curl.m_state == Curl::State::DONE;
+    });
 }
 
 } // namepace http

--- a/arbiter/util/http.cpp
+++ b/arbiter/util/http.cpp
@@ -177,9 +177,9 @@ Pool::Pool(
         const std::string& config)
     : m_retry(retry)
 {
+    curl_global_init(CURL_GLOBAL_ALL);
     for (std::size_t i = 0; i < concurrent; ++i)
         m_curls.emplace_back(i, config);
-    curl_global_init(CURL_GLOBAL_ALL);
     m_multi = curl_multi_init();
     m_runner = std::thread(&Pool::run, this);
 }

--- a/arbiter/util/http.cpp
+++ b/arbiter/util/http.cpp
@@ -270,7 +270,7 @@ bool Pool::handleCompleted()
 }
 
 // Abort all the running transfers as curl has failed internally. Remove the handle.
-// Set the state to done. Update the http code and return the notification state..
+// Set the state to done. Update the http code and return the notification state.
 bool Pool::handleFailure()
 {
     bool notify = false;

--- a/arbiter/util/http.cpp
+++ b/arbiter/util/http.cpp
@@ -210,7 +210,7 @@ void Pool::run()
         int still_running;
         CURLMcode result = curl_multi_perform(m_multi, &still_running);
         if (result == CURLM_OK)
-            result = curl_multi_poll(m_multi, NULL, 0, 500, NULL);
+            result = curl_multi_poll(m_multi, NULL, 0, 200, NULL);
 
         bool notify;
         if (result != CURLM_OK)
@@ -307,13 +307,15 @@ Resource Pool::acquire()
     m_cv.wait(lock, [this, &foundCurl]()
     {
         for (Curl& curl : m_curls)
+        {
             if (curl.m_state == Curl::State::UNUSED)
             {
                 curl.m_state = Curl::State::ACQUIRED;
                 foundCurl = &curl;
                 return true;
             }
-            return false;
+        }
+        return false;
      });
 
     // Return the resource with the acquired Curl.

--- a/arbiter/util/http.hpp
+++ b/arbiter/util/http.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #ifndef ARBITER_IS_AMALGAMATION
@@ -28,7 +29,7 @@ namespace http
 /** Perform URI percent-encoding, without encoding characters included in
  * @p exclusions.
  */
-ARBITER_DLL std::string sanitize(std::string path, std::string exclusions = "/");
+ARBITER_DLL std::string sanitize(const std::string& path, const std::string& exclusions = "/");
 
 /** Build a query string from key-value pairs.  If @p query is empty, the
  * result is an empty string.  Otherwise, the result will start with the
@@ -43,7 +44,7 @@ class ARBITER_DLL Pool;
 class ARBITER_DLL Resource
 {
 public:
-    Resource(Pool& pool, Curl& curl, std::size_t id, std::size_t retry);
+    Resource(Pool& pool, Curl& curl, std::size_t retry);
     ~Resource();
 
     http::Response get(
@@ -76,7 +77,6 @@ public:
 private:
     Pool& m_pool;
     Curl& m_curl;
-    std::size_t m_id;
     std::size_t m_retry;
 
     http::Response exec(std::function<http::Response()> f, int retry = -1);
@@ -89,20 +89,32 @@ class ARBITER_DLL Pool
 
 public:
     Pool() : Pool(4, 4, "") { }
-    Pool(std::size_t concurrent, std::size_t retry, std::string j);
+    Pool(std::size_t concurrent, std::size_t retry, const std::string& config);
     ~Pool();
 
     Resource acquire();
+    void wakeup();
+    void perform(Curl& curl);
 
 private:
-    void release(std::size_t id);
+    void run();
+    void release(Curl& curl);
+    void handleReady();
+    bool handleFailure();
+    bool handleCompleted();
 
-    std::vector<std::unique_ptr<Curl>> m_curls;
-    std::vector<std::size_t> m_available;
+    CURL *m_multi;
+    std::vector<Curl> m_curls;
+    std::thread m_runner;
     std::size_t m_retry;
+    std::atomic<bool> m_stop;
 
     std::mutex m_mutex;
+    // Provide notification between a thread waiting on a Curl and one
+    // making one available.
     std::condition_variable m_cv;
+    // Provide notification between the run thread and those waiting.
+    std::condition_variable m_poolCv;
 };
 
 /** @endcond */

--- a/arbiter/util/http.hpp
+++ b/arbiter/util/http.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <cstddef>
 #include <functional>

--- a/arbiter/util/types.hpp
+++ b/arbiter/util/types.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <map>
 #include <stdexcept>
 #include <string>

--- a/arbiter/util/types.hpp
+++ b/arbiter/util/types.hpp
@@ -141,7 +141,7 @@ private:
         }
 
         // Remove trailing \r or \n
-        const char *end = in + size;
+        const char *end = in + size - 1;
         while (size && (*end == '\n' || *end == '\r'))
         {
             end--;

--- a/arbiter/util/types.hpp
+++ b/arbiter/util/types.hpp
@@ -31,44 +31,136 @@ using Query = std::map<std::string, std::string>;
 
 /** @cond arbiter_internal */
 
+class PutData
+{
+public:
+    void init(const std::vector<char>& data)
+    {
+        m_data = data;
+        m_offset = 0;
+    }
+
+    void init(std::vector<char>&& data)
+    {
+        m_data = std::move(data);
+        m_offset = 0;
+    }
+
+    static size_t putCb(char* out, std::size_t size, std::size_t num, void *cbData)
+    {
+        PutData& putData = *static_cast<PutData *>(cbData);
+
+        size *= num;  // Size is really size * num;
+        return putData.extract(out, size);
+    }
+
+private:
+    size_t extract(char *out, size_t size)
+    {
+        size_t remaining = m_data.size() - m_offset;
+        size_t extractCount = (std::min)(size, remaining);
+
+        std::memcpy(out, m_data.data() + m_offset, extractCount);
+        m_offset += extractCount;
+        return extractCount;
+    }
+
+    std::vector<char> m_data;
+    size_t m_offset = 0;
+};
+
 class Response
 {
 public:
-    Response(int code = 0)
-        : m_code(code)
-        , m_data()
-    { }
+    void init(std::size_t reserve)
+    {
+        m_data.reserve(reserve);
+        init();
+    }
 
-    Response(int code, std::vector<char> data)
-        : m_code(code)
-        , m_data(data)
-    { }
-
-    Response(
-            int code,
-            const std::vector<char>& data,
-            const Headers& headers)
-        : m_code(code)
-        , m_data(data)
-        , m_headers(headers)
-    { }
-
-    ~Response() { }
+    void init()
+    {
+        m_code = 0;
+        m_data.clear();
+        m_headers.clear();
+    }
 
     bool ok() const             { return m_code / 100 == 2; }
     bool clientError() const    { return m_code / 100 == 4; }
     bool serverError() const    { return m_code / 100 == 5; }
     int code() const            { return m_code; }
+    void setCode(long code)     { m_code = code; }
 
-    std::vector<char> data() const { return m_data; }
-    const Headers& headers() const { return m_headers; }
-    std::string str() const
+    // We move data out of the response, so only call once.
+    std::vector<char>&& data() { return std::move(m_data); }
+    Headers headers() { return std::move(m_headers); }
+    std::string str()
     {
-        return std::string(data().data(), data().size());
+        std::string s(m_data.data(), m_data.size());
+        // Clear data for consistency with data().
+        m_data.clear();
+        return s;
+    }
+
+    static size_t getCb(const char *in, size_t size, size_t num, void *cbData)
+    {
+        Response& response = *static_cast<Response *>(cbData);
+
+        size *= num;  // Size is really size * num.
+        response.append(in, size);
+        return size;
+    }
+
+    static size_t headerCb(const char *in, std::size_t size, std::size_t num, void *cbData)
+    {
+        Response& response = *static_cast<Response *>(cbData);
+
+        size *= num;  // Size is really size * num.
+        response.addHeaders(in, size);
+        return size;
     }
 
 private:
-    int m_code;
+    void append(const char *in, size_t size)
+    {
+        std::size_t startSize = m_data.size();
+        m_data.resize(startSize + size);
+        std::memcpy(m_data.data() + startSize, in, size);
+    }
+
+    void addHeaders(const char *in, size_t size)
+    {
+        // Not sure the case where we'd have \r\n where we'd also have a valid
+        // header, but older code handled this.
+        // Remove leading \r or \n
+        while (size && (*in == '\n' || *in == '\r'))
+        {
+            in++;
+            size--;
+        }
+
+        // Remove trailing \r or \n
+        const char *end = in + size;
+        while (size && (*end == '\n' || *end == '\r'))
+        {
+            end--;
+            size--;
+        }
+
+        std::string_view data(in, size);
+
+        const std::size_t split(data.find_first_of(":"));
+
+        // No colon means it isn't a header with data.
+        if (split != std::string::npos)
+        {
+            std::string_view key(data.substr(0, split));
+            std::string_view val(data.substr(split + 1));
+            m_headers.emplace(key, val);
+        }
+    }
+
+    long m_code;
     std::vector<char> m_data;
     Headers m_headers;
 };

--- a/arbiter/util/util.hpp
+++ b/arbiter/util/util.hpp
@@ -64,7 +64,7 @@ inline bool isDirectory(std::string path)
     return (path.size() && isSlash(path.back())) || isGlob(path);
 }
 
-inline std::string joinImpl(bool first = false) { return std::string(); }
+inline std::string joinImpl(bool /* first */) { return std::string(); }
 
 template <typename ...Paths>
 inline std::string joinImpl(

--- a/cmdline/cmdline.cpp
+++ b/cmdline/cmdline.cpp
@@ -1,0 +1,144 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "arbiter.hpp"
+
+using StringList = std::vector<std::string>;
+
+using namespace arbiter;
+
+Arbiter arb;
+drivers::Http driver(arb.httpPool());
+
+int get(const StringList& args)
+{
+    if (args.size() < 1 || args.size() > 2)
+        return -1;
+
+    const std::string& url = args[0];
+    std::vector<char> v = driver.getBinary(url, http::Headers(), http::Query());
+    if (args.size() == 2)
+    {
+        std::ofstream out(args[1], std::ios::binary | std::ios::trunc);
+        if (!out)
+        {
+            std::cerr << "Couldn't open file '" << args[1] << "' for output.\n";
+            return -1;
+        }
+        out.write(v.data(), v.size());
+    }
+    std::cerr << "Received = " << v.size() << " bytes.\n";
+    return 0;
+}
+
+int size(const StringList& args)
+{
+    if (args.size() != 1)
+        return -1;
+
+    const std::string& url = args[0];
+    std::unique_ptr<std::size_t> pSize = driver.tryGetSize(url);
+    if (!pSize)
+        std::cerr << "Couldn't get size for '" << url << "'.\n";
+    else
+        std::cerr << "Size: " << *pSize << "\n";
+    return 0;
+}
+
+int put(const StringList& args)
+{
+    if (args.size() != 2)
+        return -1;
+
+    const std::string& file = args[0];
+    const std::string& url = args[1];
+
+    std::ifstream in(file, std::ios::binary);
+    if (!in)
+        throw ArbiterError("Couldn't open file '" + file + "' for input.\n");
+
+    std::string buf(std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>());
+    std::vector<char> data = driver.put(url, buf, http::Headers(), http::Query());
+    if (data.size())
+    {
+        buf.assign(data.data(), data.size());
+        std::cerr << "Received = " << buf << "!\n";
+    }
+
+    return 0;
+}
+
+int post(const StringList& args)
+{
+    if (args.size() != 2)
+        return -1;
+
+    const std::string& file = args[0];
+    const std::string& url = args[1];
+
+    std::ifstream in(file, std::ios::binary);
+    if (!in)
+        throw ArbiterError("Couldn't open file '" + file + "' for input.\n");
+
+    std::string buf(std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>());
+    driver.post(url, buf, http::Headers(), http::Query());
+
+    return 0;
+}
+
+std::string getUserAgent()
+{
+    return "arbiter (1.0)";
+}
+
+int usage()
+{
+    std::cerr << "usage:\n";
+    std::cerr << "\tarb get <url> [filename]\n";
+    std::cerr << "\tarb size <url>\n";
+    std::cerr << "\tarb put <filename> <url>\n";
+    std::cerr << "\tarb post <filename> <url>\n";
+    return -1;
+}
+
+int handleCommand(const std::string& cmd, const StringList& args)
+{
+    int status = -1;
+    try
+    {
+        if (cmd == "get")
+            status = get(args);
+        else if (cmd == "put")
+            status = put(args);
+        else if (cmd == "post")
+            status = post(args);
+        else if (cmd == "size")
+            status = size(args);
+    }
+    catch (const ArbiterError& err)
+    {
+        std::cerr << "Error: " << err.what() << ".\n";
+        return -1;
+    }
+
+    if (status)
+        return usage();
+    return status;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2)
+        return usage();
+
+    std::string cmd = argv[1];
+
+    StringList args;
+    for (size_t i = 2; i < (size_t)argc; ++i)
+        args.push_back(argv[i]);
+
+    handleCommand(cmd, args);
+    return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_executable(arbiter-test unit.cpp)
 
-target_link_libraries(arbiter-test PRIVATE arbiter gtest gtest_main )
+target_link_libraries(arbiter-test PRIVATE arbiter GTest::gtest GTest::gtest_main )
 set_target_properties(arbiter-test
     PROPERTIES
         COMPILE_DEFINITIONS ARBITER_DLL_IMPORT)
 
 
-    
+
 # We're overriding the test with a custom command for individual test output
 # and colors, which cmake doesn't like.
 set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -204,7 +204,7 @@ const auto tests = std::accumulate(
             return out;
         });
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
         ConfiguredTests,
         DriverTest,
         ::testing::ValuesIn(tests));


### PR DESCRIPTION
This replaces arbiter's use of the curl "easy" interface with the curl "multi" interface. This was recommended by the author of curl in order to reduce file descriptor use. Each easy "handle" would use at least three file descriptors to facilitate an http transfer. The multi interface uses a single descriptor for each transfer in addition to a couple of descriptors to facilitate asynchronous I/O. This should allow more transfers to occur without running out of file descriptors on system where they are a limited resource.

This change also does modifies the interface internally so that fetched data is moved rather than copied where possible.